### PR TITLE
Add remix workflow with GPT-5 video titling

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -3,7 +3,7 @@ import OpenAI from 'openai';
 
 export async function POST(request: NextRequest) {
   try {
-    const { messages } = await request.json();
+    const { messages, remixContext } = await request.json();
     const apiKey = request.headers.get('x-api-key');
 
     if (!apiKey) {
@@ -40,10 +40,26 @@ export async function POST(request: NextRequest) {
       return formattedMsg;
     });
 
+    // Build instructions with remix context if provided
+    let instructions = 'You\'re a casual, friendly creative partner helping someone make a video. Keep responses SHORT (1-3 sentences max). Be conversational and natural - like texting a friend. Ask simple questions to understand what they want - focus on content, style, mood, and story. Don\'t ask about video duration or resolution (those are in the config panel). Don\'t be formal or overly enthusiastic. Just vibe with their ideas and help them explore what they\'re going for. Never mention technical features unless they ask. When analyzing images, describe what you see and how it could be used in a video. IMPORTANT: If the user indicates they\'re happy with the idea and ready to generate the video (e.g., "let\'s do it", "I\'m ready", "let\'s make it", "sounds good"), respond with ONLY this JSON: {"readyToGenerate": true, "message": "Sweet! Hit that Generate Video button and let\'s make it happen 🎬"}';
+
+    if (remixContext) {
+      const { videoTitle, previousChat } = remixContext;
+      instructions = `You're a casual, friendly creative partner helping someone REMIX an existing video. Keep responses SHORT (1-3 sentences max). Be conversational and natural - like texting a friend.
+
+REMIX CONTEXT:
+- Original Video Title: "${videoTitle}"
+${previousChat ? `- Original Conversation:\n${previousChat}` : ''}
+
+The user wants to modify/remix this video. Help them describe what changes they want to make - focus on what should be different, what should stay the same, content modifications, style changes, mood adjustments, or story alterations. Don't ask about video duration or resolution (those are in the config panel). Just vibe with their remix ideas and help them articulate the changes they want.
+
+IMPORTANT: If the user indicates they're happy with the remix idea and ready to generate (e.g., "let's do it", "I'm ready", "let's make it", "sounds good"), respond with ONLY this JSON: {"readyToGenerate": true, "message": "Sweet! Hit that Generate Video button and let's remix it 🎬"}`;
+    }
+
     const response = await openai.responses.create({
       model: 'gpt-5',
       reasoning: { effort: 'low' },
-      instructions: 'You\'re a casual, friendly creative partner helping someone make a video. Keep responses SHORT (1-3 sentences max). Be conversational and natural - like texting a friend. Ask simple questions to understand what they want - focus on content, style, mood, and story. Don\'t ask about video duration or resolution (those are in the config panel). Don\'t be formal or overly enthusiastic. Just vibe with their ideas and help them explore what they\'re going for. Never mention technical features unless they ask. When analyzing images, describe what you see and how it could be used in a video. IMPORTANT: If the user indicates they\'re happy with the idea and ready to generate the video (e.g., "let\'s do it", "I\'m ready", "let\'s make it", "sounds good"), respond with ONLY this JSON: {"readyToGenerate": true, "message": "Sweet! Hit that Generate Video button and let\'s make it happen 🎬"}',
+      instructions,
       input,
     });
 

--- a/app/api/videos/remix/[videoId]/route.ts
+++ b/app/api/videos/remix/[videoId]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { videoId: string } }
+) {
+  try {
+    const { videoId } = params;
+    const { prompt, model, size, seconds } = await request.json();
+    const apiKey = request.headers.get('x-api-key');
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'API key is required' },
+        { status: 401 }
+      );
+    }
+
+    if (!videoId) {
+      return NextResponse.json(
+        { error: 'Video ID is required' },
+        { status: 400 }
+      );
+    }
+
+    if (!prompt || typeof prompt !== 'string') {
+      return NextResponse.json(
+        { error: 'Prompt is required' },
+        { status: 400 }
+      );
+    }
+
+    const openai = new OpenAI({ apiKey });
+
+    const remixOptions: Record<string, any> = { prompt };
+
+    if (model) remixOptions.model = model;
+    if (size) remixOptions.size = size;
+    if (seconds) remixOptions.seconds = seconds;
+
+    const video = await openai.videos.remix(videoId, remixOptions);
+
+    return NextResponse.json({
+      id: video.id,
+      status: video.status,
+      progress: video.progress || 0,
+      remixed_from_video_id: video.remixed_from_video_id ?? videoId,
+    });
+  } catch (error: any) {
+    console.error('Video remix error:', error);
+    return NextResponse.json(
+      { error: error.message || 'Failed to remix video' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/videos/remix/[videoId]/route.ts
+++ b/app/api/videos/remix/[videoId]/route.ts
@@ -3,10 +3,10 @@ import OpenAI from 'openai';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { videoId: string } }
+  { params }: { params: Promise<{ videoId: string }> }
 ) {
   try {
-    const { videoId } = params;
+    const { videoId } = await params;
     const { prompt, model, size, seconds } = await request.json();
     const apiKey = request.headers.get('x-api-key');
 
@@ -33,13 +33,8 @@ export async function POST(
 
     const openai = new OpenAI({ apiKey });
 
-    const remixOptions: Record<string, any> = { prompt };
-
-    if (model) remixOptions.model = model;
-    if (size) remixOptions.size = size;
-    if (seconds) remixOptions.seconds = seconds;
-
-    const video = await openai.videos.remix(videoId, remixOptions);
+    // Remix API only accepts prompt parameter
+    const video = await openai.videos.remix(videoId, { prompt });
 
     return NextResponse.json({
       id: video.id,

--- a/app/api/videos/title/route.ts
+++ b/app/api/videos/title/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { description } = await request.json();
+    const apiKey = request.headers.get('x-api-key');
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'API key is required' },
+        { status: 401 }
+      );
+    }
+
+    if (!description || typeof description !== 'string') {
+      return NextResponse.json(
+        { error: 'Description is required' },
+        { status: 400 }
+      );
+    }
+
+    const openai = new OpenAI({ apiKey });
+
+    const response = await openai.responses.create({
+      model: 'gpt-5',
+      instructions:
+        'Create a concise, cinematic video title (max 8 words) based on the provided description. Respond with the title only and do not include quotation marks or additional commentary.',
+      input: description,
+    });
+
+    const title = response.output_text?.trim();
+    const safeTitle = title ? title.replace(/^["']|["']$/g, '') : 'Untitled Video';
+
+    return NextResponse.json({ title: safeTitle });
+  } catch (error: any) {
+    console.error('Video title generation error:', error);
+    return NextResponse.json(
+      { error: error.message || 'Failed to generate title' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/chat/ChatMessage.tsx
+++ b/components/chat/ChatMessage.tsx
@@ -33,8 +33,48 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
 
   // Render info messages (video generation notifications)
   if (isInfo) {
-    const isCompleted = !!message.videoId;
-    const title = isCompleted ? 'Video Generated' : 'Generating Video';
+    const metadata = message.metadata;
+
+    if (metadata?.type === 'remix_reference') {
+      return (
+        <div className="flex justify-center mb-4">
+          <div className="flex items-center gap-3 px-4 py-3 bg-gradient-to-r from-purple-50 to-teal-50 border border-purple-200 rounded-lg shadow-sm">
+            <div className="flex-shrink-0 w-10 h-10 bg-purple-100 rounded-full flex items-center justify-center">
+              <svg className="w-5 h-5 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-medium text-gray-900">Remix Source Selected</p>
+              <p className="text-xs text-gray-700 font-semibold">{metadata.title}</p>
+              <p className="text-xs text-gray-600">{message.content}</p>
+            </div>
+            {message.videoId && (
+              <button
+                onClick={() => handleDownload(message.videoId!)}
+                className="flex items-center gap-2 px-3 py-1.5 bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors text-sm font-medium"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+                Download
+              </button>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    const isCompleted = metadata?.status === 'completed' || !!message.videoId;
+    const isRemix = metadata?.isRemix;
+    const titleText = metadata?.title;
+    const mainTitle = isCompleted
+      ? isRemix
+        ? 'Remix Ready'
+        : 'Video Generated'
+      : isRemix
+        ? 'Remixing Video'
+        : 'Generating Video';
     const iconColor = isCompleted ? 'text-teal-600' : 'text-blue-600';
     const bgColor = isCompleted ? 'bg-teal-100' : 'bg-blue-100';
 
@@ -47,7 +87,10 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
             </svg>
           </div>
           <div className="flex-1">
-            <p className="text-sm font-medium text-gray-900">{title}</p>
+            <p className="text-sm font-medium text-gray-900">{mainTitle}</p>
+            {titleText && (
+              <p className="text-xs text-gray-700 font-semibold">{titleText}</p>
+            )}
             <p className="text-xs text-gray-600">{message.content}</p>
           </div>
           {message.videoId && (

--- a/components/ui/ConfigPanel.tsx
+++ b/components/ui/ConfigPanel.tsx
@@ -4,7 +4,7 @@ import { useAppStore } from '@/store/useAppStore';
 import React, { useEffect } from 'react';
 
 export const ConfigPanel: React.FC = () => {
-  const { videoConfig, setVideoConfig, selectedModel } = useAppStore();
+  const { videoConfig, setVideoConfig, selectedModel, remixReference, clearRemixReference } = useAppStore();
 
   const allSizeOptions = [
     { value: '1280x720', label: '1280x720 (HD Landscape)', models: ['sora-2', 'sora-2-pro'] },
@@ -46,7 +46,27 @@ export const ConfigPanel: React.FC = () => {
         </div>
 
         {/* Size Selection */}
-        <div>
+        <div className="space-y-3">
+          {remixReference && (
+            <div className="bg-purple-50 border border-purple-200 rounded-lg px-3 py-3 flex items-start gap-3">
+              <div className="flex-shrink-0 w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
+                <svg className="w-4 h-4 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold text-purple-700">Remixing:</p>
+                <p className="text-xs text-gray-700 truncate">{remixReference.title}</p>
+                <button
+                  onClick={clearRemixReference}
+                  className="mt-2 text-xs text-purple-600 hover:text-purple-800"
+                >
+                  Clear remix reference
+                </button>
+              </div>
+            </div>
+          )}
+
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Resolution
           </label>

--- a/components/ui/LibraryPanel.tsx
+++ b/components/ui/LibraryPanel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useAppStore } from '@/store/useAppStore';
 import { apiCall } from '@/lib/api';
+import { useAppStore } from '@/store/useAppStore';
+import { useEffect, useState } from 'react';
 import { Modal } from './Modal';
 
 interface VideoItem {
@@ -81,6 +81,12 @@ export function LibraryPanel() {
 
   const getSavedVideo = (videoId: string) => savedVideos.find((video) => video.videoId === videoId);
 
+  const isVideoExpired = (createdAt: number) => {
+    const expirationTime = createdAt + 3600; // 1 hour in seconds
+    const currentTime = Math.floor(Date.now() / 1000); // current time in seconds
+    return currentTime > expirationTime;
+  };
+
   const handleReference = (video: VideoItem) => {
     const savedVideo = getSavedVideo(video.id);
     const title = savedVideo?.title || video.prompt || `Video ${video.id}`;
@@ -143,71 +149,81 @@ export function LibraryPanel() {
                   className="border border-gray-200 rounded-lg p-4 hover:border-teal-300 transition-colors cursor-pointer"
                   onClick={() => setSelectedVideo(video)}
                 >
-                <div className="flex items-start justify-between mb-3">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 mb-2">
-                      <span
-                        className={`text-xs px-2 py-1 rounded-full font-medium ${getStatusColor(
-                          video.status
-                        )}`}
-                      >
-                        {video.status}
-                      </span>
-                      {video.model && (
-                        <span className="text-xs text-gray-500">{video.model}</span>
+                  <div className="flex items-start justify-between mb-3">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span
+                          className={`text-xs px-2 py-1 rounded-full font-medium ${getStatusColor(
+                            video.status
+                          )}`}
+                        >
+                          {video.status}
+                        </span>
+                        {video.model && (
+                          <span className="text-xs text-gray-500">{video.model}</span>
+                        )}
+                      </div>
+                      <p className="text-sm font-semibold text-gray-900 line-clamp-2">
+                        {displayTitle}
+                      </p>
+                      <p className="text-xs text-gray-500 mt-1">
+                        {formatDate(video.created_at)}
+                      </p>
+                      {remixedFromTitle && (
+                        <p className="text-xs text-purple-600 mt-1">Remix of {remixedFromTitle}</p>
                       )}
                     </div>
-                    <p className="text-sm font-semibold text-gray-900 line-clamp-2">
-                      {displayTitle}
-                    </p>
-                    <p className="text-xs text-gray-500 mt-1">
-                      {formatDate(video.created_at)}
-                    </p>
-                    {remixedFromTitle && (
-                      <p className="text-xs text-purple-600 mt-1">Remix of {remixedFromTitle}</p>
-                    )}
                   </div>
+
+                  {video.prompt && (
+                    <p className="text-sm text-gray-700 line-clamp-2 mb-3">
+                      {video.prompt}
+                    </p>
+                  )}
+
+                  {video.status === 'completed' && (
+                    <div className="flex gap-2">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleReference(video);
+                        }}
+                        className="flex-1 px-3 py-2 bg-purple-100 text-purple-700 text-sm rounded hover:bg-purple-200"
+                      >
+                        Reference
+                      </button>
+                      {isVideoExpired(video.created_at) ? (
+                        <button
+                          disabled
+                          className="flex-1 px-3 py-2 bg-gray-300 text-gray-500 text-sm rounded cursor-not-allowed"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Expired
+                        </button>
+                      ) : (
+                        <a
+                          href={getVideoUrl(video.id)}
+                          download
+                          className="flex-1 px-3 py-2 bg-teal-600 text-white text-sm rounded hover:bg-teal-700 text-center"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Download
+                        </a>
+                      )}
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedVideo(video);
+                        }}
+                        className="px-3 py-2 bg-gray-100 text-gray-700 text-sm rounded hover:bg-gray-200"
+                      >
+                        View
+                      </button>
+                    </div>
+                  )}
                 </div>
-
-                {video.prompt && (
-                  <p className="text-sm text-gray-700 line-clamp-2 mb-3">
-                    {video.prompt}
-                  </p>
-                )}
-
-                {video.status === 'completed' && (
-                  <div className="flex gap-2">
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleReference(video);
-                      }}
-                      className="flex-1 px-3 py-2 bg-purple-100 text-purple-700 text-sm rounded hover:bg-purple-200"
-                    >
-                      Reference
-                    </button>
-                    <a
-                      href={getVideoUrl(video.id)}
-                      download
-                      className="flex-1 px-3 py-2 bg-teal-600 text-white text-sm rounded hover:bg-teal-700 text-center"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      Download
-                    </a>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedVideo(video);
-                      }}
-                      className="px-3 py-2 bg-gray-100 text-gray-700 text-sm rounded hover:bg-gray-200"
-                    >
-                      View
-                    </button>
-                  </div>
-                )}
-              </div>
-            );
-            }))}
+              );
+            })}
           </div>
         )}
       </div>
@@ -236,13 +252,22 @@ export function LibraryPanel() {
               </video>
             </div>
             <div className="flex gap-2">
-              <a
-                href={getVideoUrl(selectedVideo.id)}
-                download
-                className="flex-1 px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700 text-center"
-              >
-                Download
-              </a>
+              {isVideoExpired(selectedVideo.created_at) ? (
+                <button
+                  disabled
+                  className="flex-1 px-4 py-2 bg-gray-300 text-gray-500 rounded cursor-not-allowed"
+                >
+                  Expired
+                </button>
+              ) : (
+                <a
+                  href={getVideoUrl(selectedVideo.id)}
+                  download
+                  className="flex-1 px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700 text-center"
+                >
+                  Download
+                </a>
+              )}
               <button
                 onClick={() => setSelectedVideo(null)}
                 className="px-4 py-2 bg-gray-100 text-gray-700 rounded hover:bg-gray-200"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vercel/analytics": "^1.5.0",
         "autoprefixer": "^10.4.21",
         "jszip": "^3.10.1",
+        "lucide-react": "^0.545.0",
         "next": "^15.5.4",
         "openai": "^6.2.0",
         "postcss": "^8.5.6",
@@ -1491,6 +1492,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.545.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.545.0.tgz",
+      "integrity": "sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@vercel/analytics": "^1.5.0",
     "autoprefixer": "^10.4.21",
     "jszip": "^3.10.1",
+    "lucide-react": "^0.545.0",
     "next": "^15.5.4",
     "openai": "^6.2.0",
     "postcss": "^8.5.6",


### PR DESCRIPTION
## Summary
- generate GPT-5 video titles during rendering and persist them with saved videos
- add remix API support plus UI actions to reference videos from history, library, and chat
- surface remix selections in chat/config panels with enriched status messaging

## Testing
- npm run lint *(fails: interactive prompt to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68e46ff5ec3c83309a9a06db9a72063d