### PR TITLE
feat: add thumbnail preview for videos in history panel

### DIFF
--- a/app/api/videos/download/[id]/route.ts
+++ b/app/api/videos/download/[id]/route.ts
@@ -16,16 +16,26 @@ export async function GET(
       );
     }
 
+    const variantParam = request.nextUrl.searchParams.get('variant');
+    const variant = variantParam === 'thumbnail' || variantParam === 'spritesheet' ? variantParam : 'video';
+
     const openai = new OpenAI({ apiKey });
-    const content = await openai.videos.downloadContent(id);
+    const content = await openai.videos.downloadContent(id, { variant });
 
     const arrayBuffer = await content.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
 
+    const variantMeta = {
+      video: { contentType: 'video/mp4', disposition: `attachment; filename="video-${id}.mp4"` },
+      thumbnail: { contentType: 'image/webp', disposition: `inline; filename="thumbnail-${id}.webp"` },
+      spritesheet: { contentType: 'image/webp', disposition: `inline; filename="spritesheet-${id}.webp"` },
+    }[variant];
+
     return new NextResponse(buffer, {
       headers: {
-        'Content-Type': 'video/mp4',
-        'Content-Disposition': `attachment; filename="video-${id}.mp4"`,
+        'Content-Type': variantMeta.contentType,
+        'Content-Disposition': variantMeta.disposition,
+        'Cache-Control': variant === 'video' ? 'no-store' : 'private, max-age=3600',
       },
     });
   } catch (error: any) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,48 @@ import { Check, DownloadCloud } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+// Thumbnail preview for a Sora video, fetched with auth header
+function VideoThumbnail({ videoId, apiKey, alt }: { videoId: string; apiKey: string; alt: string }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let revoked = false;
+    let objectUrl: string | null = null;
+
+    fetch(`/api/videos/download/${videoId}?variant=thumbnail`, {
+      headers: { 'x-api-key': apiKey },
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error('thumbnail fetch failed');
+        return r.blob();
+      })
+      .then((blob) => {
+        if (revoked) return;
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      })
+      .catch(() => setFailed(true));
+
+    return () => {
+      revoked = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [videoId, apiKey]);
+
+  if (failed) return null;
+
+  return (
+    <div className="relative w-full aspect-video mb-2 overflow-hidden rounded-md bg-gray-100">
+      {url ? (
+        <img src={url} alt={alt} className="w-full h-full object-cover" />
+      ) : (
+        <div className="w-full h-full animate-pulse bg-gray-200" />
+      )}
+    </div>
+  );
+}
+
 // Video History Content Component
 function VideoHistoryContent() {
   const { apiKey, savedVideos, loadConversation, referenceVideoForRemix } = useAppStore();
@@ -161,6 +203,9 @@ function VideoHistoryContent() {
             key={video.id}
             className="p-3 border border-gray-200 rounded-lg hover:border-gray-300 transition-colors"
           >
+            {video.status === 'completed' && !video.expired && apiKey && (
+              <VideoThumbnail videoId={video.id} apiKey={apiKey} alt={displayTitle} />
+            )}
             <p className="text-sm font-semibold text-gray-900 line-clamp-2 mb-1">
               {displayTitle}
             </p>


### PR DESCRIPTION
## Summary

Adds an inline thumbnail preview to each video card in the **Videos** tab of the left sidebar (`VideoHistoryContent` in `app/page.tsx`). Previously, cards only showed prompt text and status — users had to download the full MP4 to see what a generation actually looked like. Now the first frame is rendered right in the list.

## Why this is useful

- **Faster visual recall** — users can scan their generation history at a glance instead of parsing prompt snippets.
- **Cheaper than streaming MP4s** — the Sora API exposes a lightweight `variant=thumbnail` (WebP) asset. We use that instead of the full video, so the list stays snappy even with many videos.
- **Pre-download validation** — users can confirm a video looks right before spending bandwidth on the MP4 download.
- **Better remix/reference UX** — choosing which video to reference becomes visual, not text-guessing.
- **No extra API surface** — reuses the existing `/api/videos/download/[id]` route with a new optional `variant` query parameter. Fully backwards compatible: `variant=video` remains the default.

## Changes

- `app/api/videos/download/[id]/route.ts`
  - Accepts `?variant=thumbnail` or `?variant=spritesheet` (defaults to `video`).
  - Returns `image/webp` with `Content-Disposition: inline` for non-video variants, plus a 1-hour private `Cache-Control` header for thumbnails.
- `app/page.tsx`
  - New `VideoThumbnail` component: authenticated blob fetch, object-URL lifecycle with cleanup on unmount, graceful fallback (pulse skeleton while loading, hidden on error).
  - Rendered at the top of each card only for `completed` and non-expired videos.

## Demo

### Before
<img width="1608" height="960" alt="Screenshot 2026-04-18 at 11 45 51" src="https://github.com/user-attachments/assets/a7cdd8e8-f653-4e51-beb4-1df623291a06" />

### After
<img width="1608" height="960" alt="Screenshot 2026-04-18 at 11 54 13" src="https://github.com/user-attachments/assets/4cca1f86-978c-4442-bc32-e0c9a1585dbe" />


## Test plan

- [x] Open the app with a valid OpenAI API key that has Sora 2 access
- [x] Generate at least one video and wait for it to reach `completed`
- [x] Open the **Videos** tab in the left sidebar — thumbnail renders at the top of the card
- [x] Pulse skeleton shows while the thumbnail is loading
- [x] Expired videos do NOT attempt to fetch a thumbnail
- [x] Failed/queued/in-progress videos do NOT show a thumbnail
- [x] Download button still returns the MP4 (no regression on `variant=video`)
- [x] DevTools → Network confirms thumbnail requests return `image/webp` with `Content-Disposition: inline`
- [x] Navigating away and back renders thumbnails again with no object-URL leaks