### PR TITLE
feat: image generation mode with history, cost preview and optional Supabase cloud sync

### DIFF
--- a/app/api/images/create/route.ts
+++ b/app/api/images/create/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import { parseOpenAIError, getStatusFromErrorCode } from '@/lib/errors';
+
+const ALLOWED_SIZES = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
+const ALLOWED_QUALITIES = new Set(['low', 'medium', 'high', 'auto']);
+const ALLOWED_MODELS = new Set(['gpt-image-1', 'gpt-image-1.5', 'gpt-image-1-mini']);
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const {
+      prompt,
+      n = 1,
+      size = '1024x1024',
+      quality = 'auto',
+      model = 'gpt-image-1.5',
+      inputImageBase64,
+    } = body;
+    const apiKey = request.headers.get('x-api-key');
+
+    if (!apiKey) {
+      return NextResponse.json({ error: 'API key is required' }, { status: 401 });
+    }
+
+    if (!prompt || typeof prompt !== 'string') {
+      return NextResponse.json({ error: 'Prompt is required' }, { status: 400 });
+    }
+
+    const count = Math.min(Math.max(Number(n) || 1, 1), 4);
+    const resolvedSize = ALLOWED_SIZES.has(size) ? size : '1024x1024';
+    const resolvedQuality = ALLOWED_QUALITIES.has(quality) ? quality : 'auto';
+    const resolvedModel = ALLOWED_MODELS.has(model) ? model : 'gpt-image-1.5';
+
+    const openai = new OpenAI({ apiKey });
+
+    let response;
+    if (inputImageBase64) {
+      const buffer = Buffer.from(inputImageBase64, 'base64');
+      const blob = new Blob([buffer], { type: 'image/png' });
+      const file = new File([blob], 'input.png', { type: 'image/png' });
+
+      response = await openai.images.edit({
+        model: resolvedModel,
+        image: file,
+        prompt,
+        n: count,
+        size: resolvedSize,
+      } as any);
+    } else {
+      response = await openai.images.generate({
+        model: resolvedModel,
+        prompt,
+        n: count,
+        size: resolvedSize,
+        quality: resolvedQuality,
+      } as any);
+    }
+
+    const images = (response.data || [])
+      .map((item: any) => item.b64_json)
+      .filter(Boolean)
+      .map((b64: string) => `data:image/png;base64,${b64}`);
+
+    return NextResponse.json({
+      images,
+      model: resolvedModel,
+      size: resolvedSize,
+      quality: resolvedQuality,
+      n: images.length,
+    });
+  } catch (error: any) {
+    console.error('Image creation error:', error);
+    const errorResponse = parseOpenAIError(error);
+    const statusCode = getStatusFromErrorCode(errorResponse.error.code);
+    return NextResponse.json(errorResponse, { status: statusCode });
+  }
+}

--- a/app/api/images/generate-stream/route.ts
+++ b/app/api/images/generate-stream/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest } from 'next/server';
+import OpenAI from 'openai';
+import { parseOpenAIError } from '@/lib/errors';
+
+const ALLOWED_SIZES = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
+const ALLOWED_QUALITIES = new Set(['low', 'medium', 'high', 'auto']);
+const ALLOWED_PARTIALS = new Set([1, 2, 3]);
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+export async function POST(request: NextRequest) {
+  const apiKey = request.headers.get('x-api-key');
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: 'API key is required' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const body = await request.json();
+  const {
+    prompt,
+    n = 1,
+    size = '1024x1024',
+    quality = 'auto',
+    partialImages = 2,
+  } = body;
+
+  if (!prompt || typeof prompt !== 'string') {
+    return new Response(JSON.stringify({ error: 'Prompt is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const count = Math.min(Math.max(Number(n) || 1, 1), 4);
+  const resolvedSize = ALLOWED_SIZES.has(size) ? size : '1024x1024';
+  const resolvedQuality = ALLOWED_QUALITIES.has(quality) ? quality : 'auto';
+  const resolvedPartials = ALLOWED_PARTIALS.has(Number(partialImages))
+    ? Number(partialImages)
+    : 2;
+
+  const openai = new OpenAI({ apiKey });
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (payload: Record<string, unknown>) => {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+      };
+
+      try {
+        for (let i = 0; i < count; i++) {
+          send({ kind: 'image_started', index: i, total: count });
+
+          const toolConfig: Record<string, unknown> = {
+            type: 'image_generation',
+            partial_images: resolvedPartials,
+          };
+          if (resolvedSize !== 'auto') toolConfig.size = resolvedSize;
+          if (resolvedQuality !== 'auto') toolConfig.quality = resolvedQuality;
+
+          const responseStream = await openai.responses.create({
+            model: 'gpt-4.1-mini',
+            input: prompt,
+            stream: true,
+            tools: [toolConfig as any],
+          });
+
+          let finalB64: string | null = null;
+
+          for await (const event of responseStream as AsyncIterable<any>) {
+            const type: string = event?.type ?? '';
+
+            if (type.includes('partial_image')) {
+              const b64 = event.partial_image_b64 ?? event.b64_json;
+              const pIdx = event.partial_image_index ?? 0;
+              if (b64) {
+                send({ kind: 'partial', index: i, partialIndex: pIdx, b64 });
+              }
+            } else if (type.includes('image_generation_call') && type.includes('completed')) {
+              finalB64 = event.result ?? event.b64_json ?? finalB64;
+            } else if (type === 'response.output_item.done') {
+              const item = event.item;
+              if (item?.type === 'image_generation_call' && item?.result) {
+                finalB64 = item.result;
+              }
+            } else if (type === 'response.completed') {
+              const outputs = event.response?.output ?? [];
+              for (const out of outputs) {
+                if (out?.type === 'image_generation_call' && out?.result) {
+                  finalB64 = out.result;
+                }
+              }
+            }
+          }
+
+          if (!finalB64) {
+            send({ kind: 'error', index: i, message: 'No image returned from stream' });
+            continue;
+          }
+
+          send({ kind: 'final', index: i, b64: finalB64 });
+        }
+
+        send({ kind: 'done' });
+        controller.close();
+      } catch (error: any) {
+        console.error('Image stream error:', error);
+        const parsed = parseOpenAIError(error);
+        send({ kind: 'error', message: parsed.error.message, code: parsed.error.code });
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { ConfigPanel } from '@/components/ui/ConfigPanel';
 import { LibraryPanel } from '@/components/ui/LibraryPanel';
 import { SettingsPanel } from '@/components/ui/SettingsPanel';
 import { useVideoGeneration } from '@/lib/useVideoGeneration';
+import { useImageGeneration } from '@/lib/useImageGeneration';
 import { useAppStore } from '@/store/useAppStore';
 import { Check, DownloadCloud } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
@@ -296,6 +297,102 @@ function ChatHistoryContent() {
   );
 }
 
+// Image History Content Component
+function ImageHistoryContent() {
+  const { savedImages, deleteImage } = useAppStore();
+
+  const handleDownload = (dataUrl: string, filename: string) => {
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = filename;
+    a.click();
+  };
+
+  if (savedImages.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 px-4 text-gray-500">
+        <svg className="w-12 h-12 mb-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        <p className="text-sm font-medium">No images yet</p>
+        <p className="text-xs text-center mt-1">Switch to Image mode and generate your first one</p>
+      </div>
+    );
+  }
+
+  const groups = Array.from(
+    savedImages.reduce((acc, img) => {
+      const list = acc.get(img.groupId) ?? [];
+      list.push(img);
+      acc.set(img.groupId, list);
+      return acc;
+    }, new Map<string, typeof savedImages>()).entries(),
+  ).sort((a, b) => b[1][0].createdAt - a[1][0].createdAt);
+
+  return (
+    <div className="p-4 space-y-4">
+      {groups.map(([groupId, images]) => {
+        const first = images[0];
+        return (
+          <div
+            key={groupId}
+            className="p-3 border border-gray-200 rounded-lg hover:border-gray-300 transition-colors"
+          >
+            <p className="text-sm font-semibold text-gray-900 line-clamp-2 mb-1">{first.title}</p>
+            <div className="flex items-center gap-2 mb-2 text-xs text-gray-500">
+              <span>{new Date(first.createdAt).toLocaleDateString()}</span>
+              <span>•</span>
+              <span>{images.length} image{images.length > 1 ? 's' : ''}</span>
+              <span>•</span>
+              <span>{first.size}</span>
+              {first.hadBaseImage && (
+                <>
+                  <span>•</span>
+                  <span className="text-purple-600">edit</span>
+                </>
+              )}
+            </div>
+            <div
+              className={`grid gap-2 ${
+                images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
+              }`}
+            >
+              {images
+                .sort((a, b) => a.indexInGroup - b.indexInGroup)
+                .map((img, idx) => (
+                  <div
+                    key={img.id}
+                    className="relative group rounded-md overflow-hidden border border-gray-200"
+                  >
+                    <img src={img.dataUrl} alt={`${img.title} ${idx + 1}`} className="w-full h-auto block" />
+                    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+                      <button
+                        onClick={() => handleDownload(img.dataUrl, `${img.title || 'image'}-${idx + 1}.png`)}
+                        className="p-2 bg-white text-teal-700 rounded-full shadow hover:bg-teal-50"
+                        title="Download"
+                      >
+                        <DownloadCloud className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => deleteImage(img.id)}
+                        className="p-2 bg-white text-red-600 rounded-full shadow hover:bg-red-50"
+                        title="Delete"
+                      >
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function Home() {
   const {
     apiKey,
@@ -306,11 +403,17 @@ export default function Home() {
     setReadyToGenerate,
     selectedModel,
     setSelectedModel,
+    generationMode,
+    setGenerationMode,
+    imageConfig,
+    setImageConfig,
+    imageGeneration,
   } = useAppStore();
   const [showApiKeyModal, setShowApiKeyModal] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
-  const [leftPanelTab, setLeftPanelTab] = useState<'videos' | 'chats'>('videos');
+  const [leftPanelTab, setLeftPanelTab] = useState<'videos' | 'images' | 'chats'>('videos');
   const { generateVideo } = useVideoGeneration();
+  const { generateImages } = useImageGeneration();
   const [isGenerateButtonLocked, setIsGenerateButtonLocked] = useState(false);
 
   useEffect(() => {
@@ -361,6 +464,23 @@ export default function Home() {
     generateVideo();
   };
 
+  const handleGenerateImages = async () => {
+    if (imageGeneration.status === 'generating') return;
+    if (!apiKey) {
+      toast.error('Please set your OpenAI API key in settings');
+      return;
+    }
+    const hasUserPrompt = chatMessages.some(
+      (m) => m.role === 'user' && m.content.trim().length > 0,
+    );
+    if (!hasUserPrompt) {
+      toast.error('Please describe the image you want in the chat');
+      return;
+    }
+    setReadyToGenerate(false);
+    generateImages();
+  };
+
   return (
     <main className="h-screen flex flex-col bg-paper-white paper-texture">
       {/* Privacy Banner */}
@@ -405,28 +525,68 @@ export default function Home() {
                 </svg>
               </button>
 
-              {/* Model Toggle */}
-              <div className="flex items-center gap-2 bg-gray-100 rounded-lg p-1">
-                <span className="text-sm font-medium text-gray-600 pl-2">Sora 2</span>
+              {/* Generation Mode Toggle */}
+              <div className="flex items-center bg-gray-100 rounded-lg p-1">
                 <button
-                  onClick={() => setSelectedModel('sora-2')}
-                  className={`px-3 py-1 rounded text-sm font-medium transition-colors ${selectedModel === 'sora-2'
+                  onClick={() => setGenerationMode('video')}
+                  className={`px-3 py-1 rounded text-sm font-medium transition-colors ${generationMode === 'video'
                     ? 'bg-teal-600 text-white'
                     : 'text-gray-600 hover:text-gray-900'
                     }`}
                 >
-                  Base
+                  Video
                 </button>
                 <button
-                  onClick={() => setSelectedModel('sora-2-pro')}
-                  className={`px-3 py-1 rounded text-sm font-medium transition-colors ${selectedModel === 'sora-2-pro'
+                  onClick={() => setGenerationMode('image')}
+                  className={`px-3 py-1 rounded text-sm font-medium transition-colors ${generationMode === 'image'
                     ? 'bg-teal-600 text-white'
                     : 'text-gray-600 hover:text-gray-900'
                     }`}
                 >
-                  Pro
+                  Image
                 </button>
               </div>
+
+              {/* Model / Quantity Selectors */}
+              {generationMode === 'video' ? (
+                <div className="flex items-center gap-2 bg-gray-100 rounded-lg p-1">
+                  <span className="text-sm font-medium text-gray-600 pl-2">Sora 2</span>
+                  <button
+                    onClick={() => setSelectedModel('sora-2')}
+                    className={`px-3 py-1 rounded text-sm font-medium transition-colors ${selectedModel === 'sora-2'
+                      ? 'bg-teal-600 text-white'
+                      : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                  >
+                    Base
+                  </button>
+                  <button
+                    onClick={() => setSelectedModel('sora-2-pro')}
+                    className={`px-3 py-1 rounded text-sm font-medium transition-colors ${selectedModel === 'sora-2-pro'
+                      ? 'bg-teal-600 text-white'
+                      : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                  >
+                    Pro
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 bg-gray-100 rounded-lg p-1">
+                  <span className="text-sm font-medium text-gray-600 pl-2">Count</span>
+                  {[1, 2, 3, 4].map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setImageConfig({ n })}
+                      className={`px-3 py-1 rounded text-sm font-medium transition-colors ${imageConfig.n === n
+                        ? 'bg-teal-600 text-white'
+                        : 'text-gray-600 hover:text-gray-900'
+                        }`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -453,6 +613,20 @@ export default function Home() {
               </div>
             </button>
             <button
+              onClick={() => setLeftPanelTab('images')}
+              className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${leftPanelTab === 'images'
+                ? 'text-teal-600 border-b-2 border-teal-600 bg-teal-50'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+                }`}
+            >
+              <div className="flex items-center justify-center gap-2">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                Images
+              </div>
+            </button>
+            <button
               onClick={() => setLeftPanelTab('chats')}
               className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${leftPanelTab === 'chats'
                 ? 'text-teal-600 border-b-2 border-teal-600 bg-teal-50'
@@ -471,6 +645,7 @@ export default function Home() {
           {/* Tab Content */}
           <div className="flex-1 overflow-y-auto">
             {leftPanelTab === 'videos' && <VideoHistoryContent />}
+            {leftPanelTab === 'images' && <ImageHistoryContent />}
             {leftPanelTab === 'chats' && <ChatHistoryContent />}
           </div>
         </div>
@@ -481,22 +656,37 @@ export default function Home() {
             <ChatPanel />
           </div>
           <div className="p-6 border-t border-gray-200">
-            <Button
-              onClick={handleGenerateVideo}
-              disabled={
-                isGenerateButtonLocked ||
-                videoGeneration.status === 'in_progress' ||
-                videoGeneration.status === 'queued'
-              }
-              className={`w-full transition-all ${readyToGenerate ? 'animate-pulse ring-4 ring-teal-300 shadow-lg scale-105' : ''}`}
-              size="lg"
-            >
-              {(videoGeneration.status === 'in_progress' || videoGeneration.status === 'queued') ? (
-                <div className="flex items-center justify-center"><div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>Generating Video ({videoGeneration.progress}%)</div>
-              ) : (
-                'Generate Video'
-              )}
-            </Button>
+            {generationMode === 'video' ? (
+              <Button
+                onClick={handleGenerateVideo}
+                disabled={
+                  isGenerateButtonLocked ||
+                  videoGeneration.status === 'in_progress' ||
+                  videoGeneration.status === 'queued'
+                }
+                className={`w-full transition-all ${readyToGenerate ? 'animate-pulse ring-4 ring-teal-300 shadow-lg scale-105' : ''}`}
+                size="lg"
+              >
+                {(videoGeneration.status === 'in_progress' || videoGeneration.status === 'queued') ? (
+                  <div className="flex items-center justify-center"><div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>Generating Video ({videoGeneration.progress}%)</div>
+                ) : (
+                  'Generate Video'
+                )}
+              </Button>
+            ) : (
+              <Button
+                onClick={handleGenerateImages}
+                disabled={imageGeneration.status === 'generating'}
+                className={`w-full transition-all ${readyToGenerate ? 'animate-pulse ring-4 ring-teal-300 shadow-lg scale-105' : ''}`}
+                size="lg"
+              >
+                {imageGeneration.status === 'generating' ? (
+                  <div className="flex items-center justify-center"><div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>Generating {imageConfig.n} image{imageConfig.n > 1 ? 's' : ''}...</div>
+                ) : (
+                  `Generate ${imageConfig.n} Image${imageConfig.n > 1 ? 's' : ''}`
+                )}
+              </Button>
+            )}
           </div>
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -364,10 +364,15 @@ function ImageHistoryContent() {
                     key={img.id}
                     className="relative group rounded-md overflow-hidden border border-gray-200"
                   >
-                    <img src={img.dataUrl} alt={`${img.title} ${idx + 1}`} className="w-full h-auto block" />
+                    {img.dataUrl ? (
+                      <img src={img.dataUrl} alt={`${img.title} ${idx + 1}`} className="w-full h-auto block" />
+                    ) : (
+                      <div className="aspect-square bg-gray-100 animate-pulse" />
+                    )}
                     <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
                       <button
-                        onClick={() => handleDownload(img.dataUrl, `${img.title || 'image'}-${idx + 1}.png`)}
+                        disabled={!img.dataUrl}
+                        onClick={() => img.dataUrl && handleDownload(img.dataUrl, `${img.title || 'image'}-${idx + 1}.png`)}
                         className="p-2 bg-white text-teal-700 rounded-full shadow hover:bg-teal-50"
                         title="Download"
                       >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -470,13 +470,21 @@ export default function Home() {
       toast.error('Please set your OpenAI API key in settings');
       return;
     }
-    const hasUserPrompt = chatMessages.some(
+
+    const state = useAppStore.getState();
+    const pending = state.chatInput.trim();
+    const hasUserPrompt = state.chatMessages.some(
       (m) => m.role === 'user' && m.content.trim().length > 0,
     );
-    if (!hasUserPrompt) {
+
+    if (pending) {
+      state.addChatMessage({ role: 'user', content: pending });
+      state.setChatInput('');
+    } else if (!hasUserPrompt) {
       toast.error('Please describe the image you want in the chat');
       return;
     }
+
     setReadyToGenerate(false);
     generateImages();
   };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -393,6 +393,88 @@ function ImageHistoryContent() {
   );
 }
 
+function useElapsedSeconds(startedAt: number | null, active: boolean) {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!active || !startedAt) {
+      setElapsed(0);
+      return;
+    }
+    setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    }, 500);
+    return () => clearInterval(id);
+  }, [startedAt, active]);
+  return elapsed;
+}
+
+function ImageGenerateButton({
+  onGenerate,
+  readyToGenerate,
+}: {
+  onGenerate: () => void;
+  readyToGenerate: boolean;
+}) {
+  const { imageGeneration, imageConfig } = useAppStore();
+  const isGenerating = imageGeneration.status === 'generating';
+  const elapsed = useElapsedSeconds(imageGeneration.startedAt, isGenerating);
+
+  return (
+    <Button
+      onClick={onGenerate}
+      disabled={isGenerating}
+      className={`w-full transition-all ${readyToGenerate ? 'animate-pulse ring-4 ring-teal-300 shadow-lg scale-105' : ''}`}
+      size="lg"
+    >
+      {isGenerating ? (
+        <div className="flex items-center justify-center">
+          <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
+          Generating {imageConfig.n} image{imageConfig.n > 1 ? 's' : ''}... {elapsed}s
+        </div>
+      ) : (
+        `Generate ${imageConfig.n} Image${imageConfig.n > 1 ? 's' : ''}`
+      )}
+    </Button>
+  );
+}
+
+function ImageGenerationPreview() {
+  const { imageGeneration, imageConfig } = useAppStore();
+  if (imageGeneration.status !== 'generating') return null;
+  const previews = imageGeneration.partialPreviews;
+  const hasAny = previews.some((p) => p);
+  if (!hasAny) return null;
+
+  return (
+    <div className="px-6 pt-4 pb-2 border-t border-gray-200 bg-gray-50">
+      <div className="text-xs text-gray-500 mb-2">
+        Live preview {imageGeneration.activeIndex + 1}/{imageConfig.n}
+      </div>
+      <div
+        className={`grid gap-2 ${
+          imageConfig.n === 1 ? 'grid-cols-1' : imageConfig.n === 2 ? 'grid-cols-2' : 'grid-cols-4'
+        }`}
+      >
+        {previews.map((src, idx) => (
+          <div
+            key={idx}
+            className={`relative aspect-square rounded-md overflow-hidden bg-white border ${
+              idx === imageGeneration.activeIndex ? 'border-teal-500' : 'border-gray-200'
+            }`}
+          >
+            {src ? (
+              <img src={src} alt={`Preview ${idx + 1}`} className="w-full h-full object-cover" />
+            ) : (
+              <div className="w-full h-full animate-pulse bg-gray-200" />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function Home() {
   const {
     apiKey,
@@ -663,6 +745,7 @@ export default function Home() {
           <div className="flex-1 overflow-hidden">
             <ChatPanel />
           </div>
+          {generationMode === 'image' && <ImageGenerationPreview />}
           <div className="p-6 border-t border-gray-200">
             {generationMode === 'video' ? (
               <Button
@@ -682,18 +765,10 @@ export default function Home() {
                 )}
               </Button>
             ) : (
-              <Button
-                onClick={handleGenerateImages}
-                disabled={imageGeneration.status === 'generating'}
-                className={`w-full transition-all ${readyToGenerate ? 'animate-pulse ring-4 ring-teal-300 shadow-lg scale-105' : ''}`}
-                size="lg"
-              >
-                {imageGeneration.status === 'generating' ? (
-                  <div className="flex items-center justify-center"><div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>Generating {imageConfig.n} image{imageConfig.n > 1 ? 's' : ''}...</div>
-                ) : (
-                  `Generate ${imageConfig.n} Image${imageConfig.n > 1 ? 's' : ''}`
-                )}
-              </Button>
+              <ImageGenerateButton
+                onGenerate={handleGenerateImages}
+                readyToGenerate={readyToGenerate}
+              />
             )}
           </div>
         </div>

--- a/components/chat/ChatMessage.tsx
+++ b/components/chat/ChatMessage.tsx
@@ -10,10 +10,23 @@ interface ChatMessageProps {
 }
 
 export const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
-  const { apiKey } = useAppStore();
+  const { apiKey, savedImages } = useAppStore();
   const isAssistant = message.role === 'assistant';
   const isInfo = message.role === 'info';
   const isError = message.role === 'error';
+
+  const attachedImages = message.imageIds
+    ? message.imageIds
+        .map((id) => savedImages.find((img) => img.id === id))
+        .filter((img): img is NonNullable<typeof img> => Boolean(img))
+    : [];
+
+  const handleImageDownload = (dataUrl: string, filename: string) => {
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = filename;
+    a.click();
+  };
 
   const handleDownload = async (videoId: string) => {
     try {
@@ -82,29 +95,60 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
 
     return (
       <div className="flex justify-center mb-4">
-        <div className="flex items-center gap-3 px-4 py-3 bg-gradient-to-r from-teal-50 to-blue-50 border border-teal-200 rounded-lg shadow-sm">
-          <div className={`flex-shrink-0 w-10 h-10 ${bgColor} rounded-full flex items-center justify-center`}>
-            <svg className={`w-5 h-5 ${iconColor}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
-            </svg>
-          </div>
-          <div className="flex-1">
-            <p className="text-sm font-medium text-gray-900">{mainTitle}</p>
-            {titleText && (
-              <p className="text-xs text-gray-700 font-semibold">{titleText}</p>
-            )}
-            <p className="text-xs text-gray-600">{message.content}</p>
-          </div>
-          {message.videoId && (
-            <button
-              onClick={() => handleDownload(message.videoId!)}
-              className="flex items-center gap-2 px-3 py-1.5 bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors text-sm font-medium"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        <div className="flex flex-col gap-3 px-4 py-3 bg-gradient-to-r from-teal-50 to-blue-50 border border-teal-200 rounded-lg shadow-sm max-w-[90%]">
+          <div className="flex items-center gap-3">
+            <div className={`flex-shrink-0 w-10 h-10 ${bgColor} rounded-full flex items-center justify-center`}>
+              <svg className={`w-5 h-5 ${iconColor}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
               </svg>
-              Download
-            </button>
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-medium text-gray-900">{mainTitle}</p>
+              {titleText && (
+                <p className="text-xs text-gray-700 font-semibold">{titleText}</p>
+              )}
+              <p className="text-xs text-gray-600">{message.content}</p>
+            </div>
+            {message.videoId && (
+              <button
+                onClick={() => handleDownload(message.videoId!)}
+                className="flex items-center gap-2 px-3 py-1.5 bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors text-sm font-medium"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+                Download
+              </button>
+            )}
+          </div>
+          {attachedImages.length > 0 && (
+            <div
+              className={`grid gap-2 ${
+                attachedImages.length === 1
+                  ? 'grid-cols-1'
+                  : attachedImages.length === 2
+                    ? 'grid-cols-2'
+                    : 'grid-cols-2'
+              }`}
+            >
+              {attachedImages.map((img, idx) => (
+                <div
+                  key={img.id}
+                  className="relative group rounded-md overflow-hidden border border-gray-200 bg-white"
+                >
+                  <img src={img.dataUrl} alt={`${img.title} ${idx + 1}`} className="w-full h-auto" />
+                  <button
+                    onClick={() => handleImageDownload(img.dataUrl, `${img.title || 'image'}-${idx + 1}.png`)}
+                    className="absolute top-2 right-2 p-1.5 bg-white bg-opacity-90 text-teal-700 rounded-full opacity-0 group-hover:opacity-100 transition-opacity shadow"
+                    title="Download image"
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                  </button>
+                </div>
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/components/chat/ChatMessage.tsx
+++ b/components/chat/ChatMessage.tsx
@@ -80,16 +80,21 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
       );
     }
 
-    const isCompleted = metadata?.status === 'completed' || !!message.videoId;
+    const isCompleted = metadata?.status === 'completed' || !!message.videoId || (message.imageIds && message.imageIds.length > 0);
     const isRemix = metadata?.isRemix;
     const titleText = metadata?.title;
-    const mainTitle = isCompleted
-      ? isRemix
-        ? 'Remix Ready'
-        : 'Video Generated'
-      : isRemix
-        ? 'Remixing Video'
-        : 'Generating Video';
+    const isImage = metadata?.mediaType === 'image' || (message.imageIds && message.imageIds.length > 0);
+    const mainTitle = isImage
+      ? isCompleted
+        ? 'Images Generated'
+        : 'Generating Images'
+      : isCompleted
+        ? isRemix
+          ? 'Remix Ready'
+          : 'Video Generated'
+        : isRemix
+          ? 'Remixing Video'
+          : 'Generating Video';
     const iconColor = isCompleted ? 'text-teal-600' : 'text-blue-600';
     const bgColor = isCompleted ? 'bg-teal-100' : 'bg-blue-100';
 

--- a/components/chat/ChatMessage.tsx
+++ b/components/chat/ChatMessage.tsx
@@ -136,9 +136,14 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
                   key={img.id}
                   className="relative group rounded-md overflow-hidden border border-gray-200 bg-white"
                 >
-                  <img src={img.dataUrl} alt={`${img.title} ${idx + 1}`} className="w-full h-auto" />
+                  {img.dataUrl ? (
+                    <img src={img.dataUrl} alt={`${img.title} ${idx + 1}`} className="w-full h-auto" />
+                  ) : (
+                    <div className="aspect-square bg-gray-100 animate-pulse" />
+                  )}
                   <button
-                    onClick={() => handleImageDownload(img.dataUrl, `${img.title || 'image'}-${idx + 1}.png`)}
+                    disabled={!img.dataUrl}
+                    onClick={() => img.dataUrl && handleImageDownload(img.dataUrl, `${img.title || 'image'}-${idx + 1}.png`)}
                     className="absolute top-2 right-2 p-1.5 bg-white bg-opacity-90 text-teal-700 rounded-full opacity-0 group-hover:opacity-100 transition-opacity shadow"
                     title="Download image"
                   >

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -26,8 +26,9 @@ export const ChatPanel: React.FC = () => {
     setVideoConfig,
     selectedModel,
     setSelectedModel,
+    chatInput: input,
+    setChatInput: setInput,
   } = useAppStore();
-  const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [showImageModal, setShowImageModal] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);

--- a/components/ui/ConfigPanel.tsx
+++ b/components/ui/ConfigPanel.tsx
@@ -3,6 +3,7 @@
 import { useAppStore } from '@/store/useAppStore';
 import React, { useEffect } from 'react';
 import { getSizeOptionsForModel } from '@/lib/videoOptions';
+import { estimateImageCost, formatCost } from '@/lib/imagePricing';
 
 const IMAGE_SIZE_OPTIONS = [
   { value: '1024x1024', label: '1024 × 1024 (Square)' },
@@ -146,6 +147,12 @@ const VideoConfig: React.FC = () => {
 
 const ImageConfig: React.FC = () => {
   const { imageConfig, setImageConfig } = useAppStore();
+  const cost = estimateImageCost({
+    model: imageConfig.model,
+    quality: imageConfig.quality,
+    size: imageConfig.size,
+    n: imageConfig.n,
+  });
 
   return (
     <>
@@ -159,6 +166,28 @@ const ImageConfig: React.FC = () => {
             Generating <span className="font-semibold text-teal-600">{imageConfig.n}</span> image{imageConfig.n > 1 ? 's' : ''} per request
           </p>
         </div>
+      </div>
+
+      <div className="bg-teal-50 border border-teal-200 rounded-lg p-3">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs font-medium text-teal-900">Estimated cost</span>
+          {cost?.approximate && (
+            <span className="text-[10px] uppercase tracking-wide text-teal-700">approx.</span>
+          )}
+        </div>
+        {cost ? (
+          <>
+            <p className="text-lg font-bold text-teal-700">
+              {cost.approximate ? '~' : ''}
+              {formatCost(cost.total)}
+            </p>
+            <p className="text-xs text-gray-600 mt-0.5">
+              {imageConfig.n} × {formatCost(cost.perImage)} per image
+            </p>
+          </>
+        ) : (
+          <p className="text-xs text-gray-500">Pricing unavailable for current selection.</p>
+        )}
       </div>
 
       <div>

--- a/components/ui/ConfigPanel.tsx
+++ b/components/ui/ConfigPanel.tsx
@@ -24,6 +24,13 @@ const IMAGE_MODEL_OPTIONS = [
   { value: 'gpt-image-1-mini', label: 'gpt-image-1-mini (cheapest)' },
 ];
 
+const PARTIAL_IMAGE_OPTIONS: Array<{ value: 0 | 1 | 2 | 3; label: string }> = [
+  { value: 0, label: 'Off (no preview, cheapest)' },
+  { value: 1, label: '1 preview frame (+100 tokens/image)' },
+  { value: 2, label: '2 preview frames (+200 tokens/image)' },
+  { value: 3, label: '3 preview frames (+300 tokens/image)' },
+];
+
 const VideoConfig: React.FC = () => {
   const { videoConfig, setVideoConfig, selectedModel, remixReference, clearRemixReference } = useAppStore();
 
@@ -207,6 +214,26 @@ const ImageConfig: React.FC = () => {
         </select>
         <p className="text-xs text-gray-500 mt-1">
           Higher quality costs more and takes longer.
+        </p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Live preview</label>
+        <select
+          value={imageConfig.partialImages}
+          onChange={(e) =>
+            setImageConfig({ partialImages: Number(e.target.value) as 0 | 1 | 2 | 3 })
+          }
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
+        >
+          {PARTIAL_IMAGE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-gray-500 mt-1">
+          Streams progressive frames as the image forms. Each preview frame adds ~100 output tokens per image. Not supported for base-image edits.
         </p>
       </div>
 

--- a/components/ui/ConfigPanel.tsx
+++ b/components/ui/ConfigPanel.tsx
@@ -4,13 +4,31 @@ import { useAppStore } from '@/store/useAppStore';
 import React, { useEffect } from 'react';
 import { getSizeOptionsForModel } from '@/lib/videoOptions';
 
-export const ConfigPanel: React.FC = () => {
+const IMAGE_SIZE_OPTIONS = [
+  { value: '1024x1024', label: '1024 × 1024 (Square)' },
+  { value: '1536x1024', label: '1536 × 1024 (Landscape)' },
+  { value: '1024x1536', label: '1024 × 1536 (Portrait)' },
+  { value: 'auto', label: 'Auto (model decides)' },
+];
+
+const IMAGE_QUALITY_OPTIONS = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'low', label: 'Low (fastest)' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High (slowest)' },
+];
+
+const IMAGE_MODEL_OPTIONS = [
+  { value: 'gpt-image-1.5', label: 'gpt-image-1.5 (recommended)' },
+  { value: 'gpt-image-1', label: 'gpt-image-1' },
+  { value: 'gpt-image-1-mini', label: 'gpt-image-1-mini (cheapest)' },
+];
+
+const VideoConfig: React.FC = () => {
   const { videoConfig, setVideoConfig, selectedModel, remixReference, clearRemixReference } = useAppStore();
 
-  // Filter size options based on selected model
   const sizeOptions = getSizeOptionsForModel(selectedModel);
 
-  // Auto-adjust size if current size is not valid for selected model
   useEffect(() => {
     const isCurrentSizeValid = sizeOptions.some(option => option.value === videoConfig.size);
     if (!isCurrentSizeValid) {
@@ -22,108 +40,204 @@ export const ConfigPanel: React.FC = () => {
   const durationOptions = [
     { value: '4', label: '4 seconds' },
     { value: '8', label: '8 seconds' },
-    { value: '12', label: '12 seconds' }
+    { value: '12', label: '12 seconds' },
   ];
+
+  return (
+    <>
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Video Configuration</h3>
+        <p className="text-sm text-gray-500 mb-4">
+          Configure the parameters for video generation
+        </p>
+        <div className="bg-gray-50 px-3 py-2 rounded-lg">
+          <p className="text-xs text-gray-600">
+            Current Model: <span className="font-semibold text-teal-600">{selectedModel === 'sora-2' ? 'Sora 2 Base' : 'Sora 2 Pro'}</span>
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {remixReference && (
+          <div className="bg-purple-50 border border-purple-200 rounded-lg px-3 py-3 flex items-start gap-3">
+            <div className="flex-shrink-0 w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
+              <svg className="w-4 h-4 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-purple-700">Remixing:</p>
+              <p className="text-xs text-gray-700 truncate">{remixReference.title}</p>
+              <button
+                onClick={clearRemixReference}
+                className="mt-2 text-xs text-purple-600 hover:text-purple-800"
+              >
+                Clear remix reference
+              </button>
+            </div>
+          </div>
+        )}
+
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Resolution
+        </label>
+        <select
+          value={videoConfig.size}
+          onChange={(e) => setVideoConfig({ size: e.target.value })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
+        >
+          {sizeOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-gray-500 mt-1">
+          {selectedModel === 'sora-2' ? (
+            <>Base model supports HD resolutions. Switch to Pro for wider formats.</>
+          ) : (
+            <>Pro model supports all resolution options.</>
+          )}
+        </p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Duration
+        </label>
+        <select
+          value={videoConfig.seconds}
+          onChange={(e) => setVideoConfig({ seconds: e.target.value })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
+        >
+          {durationOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-gray-500 mt-1">
+          Select video length in seconds
+        </p>
+      </div>
+
+      <div className="border-t pt-6">
+        <div className="bg-teal-50 border border-teal-200 rounded-lg p-4">
+          <div className="flex items-start gap-2">
+            <svg className="w-5 h-5 text-teal-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="text-sm text-gray-700">
+              <p className="font-medium text-teal-900 mb-1">Configuration Tips</p>
+              <ul className="space-y-1 text-gray-600">
+                <li>• Higher resolutions take longer to generate</li>
+                <li>• Longer durations may cost more credits</li>
+                <li>• Portrait sizes are ideal for social media</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const ImageConfig: React.FC = () => {
+  const { imageConfig, setImageConfig } = useAppStore();
+
+  return (
+    <>
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Image Configuration</h3>
+        <p className="text-sm text-gray-500 mb-4">
+          Configure the parameters for image generation
+        </p>
+        <div className="bg-gray-50 px-3 py-2 rounded-lg">
+          <p className="text-xs text-gray-600">
+            Generating <span className="font-semibold text-teal-600">{imageConfig.n}</span> image{imageConfig.n > 1 ? 's' : ''} per request
+          </p>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Model</label>
+        <select
+          value={imageConfig.model}
+          onChange={(e) => setImageConfig({ model: e.target.value })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
+        >
+          {IMAGE_MODEL_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-gray-500 mt-1">
+          gpt-image-1.5 offers the best quality; mini is cheaper and faster.
+        </p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Size</label>
+        <select
+          value={imageConfig.size}
+          onChange={(e) => setImageConfig({ size: e.target.value })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
+        >
+          {IMAGE_SIZE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Quality</label>
+        <select
+          value={imageConfig.quality}
+          onChange={(e) => setImageConfig({ quality: e.target.value })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
+        >
+          {IMAGE_QUALITY_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-gray-500 mt-1">
+          Higher quality costs more and takes longer.
+        </p>
+      </div>
+
+      <div className="border-t pt-6">
+        <div className="bg-teal-50 border border-teal-200 rounded-lg p-4">
+          <div className="flex items-start gap-2">
+            <svg className="w-5 h-5 text-teal-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="text-sm text-gray-700">
+              <p className="font-medium text-teal-900 mb-1">Configuration Tips</p>
+              <ul className="space-y-1 text-gray-600">
+                <li>• Attach a base image to edit it instead of generating fresh</li>
+                <li>• Use the counter in the header to generate 1–4 variations</li>
+                <li>• Square sizes tend to produce the most consistent results</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export const ConfigPanel: React.FC = () => {
+  const { generationMode } = useAppStore();
 
   return (
     <div className="w-80 border-l border-gray-200 bg-white p-6 overflow-y-auto">
       <div className="space-y-6">
-        <div>
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Video Configuration</h3>
-          <p className="text-sm text-gray-500 mb-4">
-            Configure the parameters for video generation
-          </p>
-          <div className="bg-gray-50 px-3 py-2 rounded-lg">
-            <p className="text-xs text-gray-600">
-              Current Model: <span className="font-semibold text-teal-600">{selectedModel === 'sora-2' ? 'Sora 2 Base' : 'Sora 2 Pro'}</span>
-            </p>
-          </div>
-        </div>
-
-        {/* Size Selection */}
-        <div className="space-y-3">
-          {remixReference && (
-            <div className="bg-purple-50 border border-purple-200 rounded-lg px-3 py-3 flex items-start gap-3">
-              <div className="flex-shrink-0 w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
-                <svg className="w-4 h-4 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-              </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-semibold text-purple-700">Remixing:</p>
-                <p className="text-xs text-gray-700 truncate">{remixReference.title}</p>
-                <button
-                  onClick={clearRemixReference}
-                  className="mt-2 text-xs text-purple-600 hover:text-purple-800"
-                >
-                  Clear remix reference
-                </button>
-              </div>
-            </div>
-          )}
-
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Resolution
-          </label>
-          <select
-            value={videoConfig.size}
-            onChange={(e) => setVideoConfig({ size: e.target.value })}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
-          >
-            {sizeOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-          <p className="text-xs text-gray-500 mt-1">
-            {selectedModel === 'sora-2' ? (
-              <>Base model supports HD resolutions. Switch to Pro for wider formats.</>
-            ) : (
-              <>Pro model supports all resolution options.</>
-            )}
-          </p>
-        </div>
-
-        {/* Duration Selection */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Duration
-          </label>
-          <select
-            value={videoConfig.seconds}
-            onChange={(e) => setVideoConfig({ seconds: e.target.value })}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
-          >
-            {durationOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-          <p className="text-xs text-gray-500 mt-1">
-            Select video length in seconds
-          </p>
-        </div>
-
-        {/* Info Section */}
-        <div className="border-t pt-6">
-          <div className="bg-teal-50 border border-teal-200 rounded-lg p-4">
-            <div className="flex items-start gap-2">
-              <svg className="w-5 h-5 text-teal-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <div className="text-sm text-gray-700">
-                <p className="font-medium text-teal-900 mb-1">Configuration Tips</p>
-                <ul className="space-y-1 text-gray-600">
-                  <li>• Higher resolutions take longer to generate</li>
-                  <li>• Longer durations may cost more credits</li>
-                  <li>• Portrait sizes are ideal for social media</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
+        {generationMode === 'image' ? <ImageConfig /> : <VideoConfig />}
       </div>
     </div>
   );

--- a/components/ui/ConfigPanel.tsx
+++ b/components/ui/ConfigPanel.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from '@/store/useAppStore';
 import React, { useEffect } from 'react';
 import { getSizeOptionsForModel } from '@/lib/videoOptions';
 import { estimateImageCost, formatCost } from '@/lib/imagePricing';
+import { estimateVideoCost } from '@/lib/videoPricing';
 
 const IMAGE_SIZE_OPTIONS = [
   { value: '1024x1024', label: '1024 × 1024 (Square)' },
@@ -31,6 +32,11 @@ const VideoConfig: React.FC = () => {
   const { videoConfig, setVideoConfig, selectedModel, remixReference, clearRemixReference } = useAppStore();
 
   const sizeOptions = getSizeOptionsForModel(selectedModel);
+  const videoCost = estimateVideoCost({
+    model: selectedModel,
+    size: videoConfig.size,
+    seconds: videoConfig.seconds,
+  });
 
   useEffect(() => {
     const isCurrentSizeValid = sizeOptions.some(option => option.value === videoConfig.size);
@@ -58,6 +64,22 @@ const VideoConfig: React.FC = () => {
             Current Model: <span className="font-semibold text-teal-600">{selectedModel === 'sora-2' ? 'Sora 2 Base' : 'Sora 2 Pro'}</span>
           </p>
         </div>
+      </div>
+
+      <div className="bg-teal-50 border border-teal-200 rounded-lg p-3">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs font-medium text-teal-900">Estimated cost</span>
+        </div>
+        {videoCost ? (
+          <>
+            <p className="text-lg font-bold text-teal-700">{formatCost(videoCost.total)}</p>
+            <p className="text-xs text-gray-600 mt-0.5">
+              {videoCost.seconds}s × {formatCost(videoCost.perSecond)}/second
+            </p>
+          </>
+        ) : (
+          <p className="text-xs text-gray-500">Pricing unavailable for current selection.</p>
+        )}
       </div>
 
       <div className="space-y-3">

--- a/components/ui/ConfigPanel.tsx
+++ b/components/ui/ConfigPanel.tsx
@@ -24,12 +24,7 @@ const IMAGE_MODEL_OPTIONS = [
   { value: 'gpt-image-1-mini', label: 'gpt-image-1-mini (cheapest)' },
 ];
 
-const PARTIAL_IMAGE_OPTIONS: Array<{ value: 0 | 1 | 2 | 3; label: string }> = [
-  { value: 0, label: 'Off (no preview, cheapest)' },
-  { value: 1, label: '1 preview frame (+100 tokens/image)' },
-  { value: 2, label: '2 preview frames (+200 tokens/image)' },
-  { value: 3, label: '3 preview frames (+300 tokens/image)' },
-];
+const LIVE_PREVIEW_PARTIAL_COUNT = 2;
 
 const VideoConfig: React.FC = () => {
   const { videoConfig, setVideoConfig, selectedModel, remixReference, clearRemixReference } = useAppStore();
@@ -218,23 +213,33 @@ const ImageConfig: React.FC = () => {
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">Live preview</label>
-        <select
-          value={imageConfig.partialImages}
-          onChange={(e) =>
-            setImageConfig({ partialImages: Number(e.target.value) as 0 | 1 | 2 | 3 })
-          }
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent bg-white text-gray-900"
-        >
-          {PARTIAL_IMAGE_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        <p className="text-xs text-gray-500 mt-1">
-          Streams progressive frames as the image forms. Each preview frame adds ~100 output tokens per image. Not supported for base-image edits.
-        </p>
+        <label className="flex items-center justify-between gap-3 cursor-pointer">
+          <div>
+            <span className="block text-sm font-medium text-gray-700">Live preview</span>
+            <span className="block text-xs text-gray-500 mt-0.5">
+              Stream progressive frames as each image forms (+200 tokens/image). Not supported for base-image edits.
+            </span>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={imageConfig.partialImages > 0}
+            onClick={() =>
+              setImageConfig({
+                partialImages: imageConfig.partialImages > 0 ? 0 : LIVE_PREVIEW_PARTIAL_COUNT,
+              })
+            }
+            className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
+              imageConfig.partialImages > 0 ? 'bg-teal-600' : 'bg-gray-300'
+            }`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+                imageConfig.partialImages > 0 ? 'translate-x-5' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </label>
       </div>
 
       <div className="border-t pt-6">

--- a/components/ui/ConfigPanel.tsx
+++ b/components/ui/ConfigPanel.tsx
@@ -213,31 +213,21 @@ const ImageConfig: React.FC = () => {
       </div>
 
       <div>
-        <label className="flex items-center justify-between gap-3 cursor-pointer">
+        <label className="flex items-center justify-between gap-3">
           <div>
-            <span className="block text-sm font-medium text-gray-700">Live preview</span>
-            <span className="block text-xs text-gray-500 mt-0.5">
-              Stream progressive frames as each image forms (+200 tokens/image). Not supported for base-image edits.
+            <span className="block text-sm font-medium text-gray-400">Live preview</span>
+            <span className="block text-xs text-gray-400 mt-0.5">
+              Stream progressive frames as each image forms (+200 tokens/image). Coming soon.
             </span>
           </div>
           <button
             type="button"
             role="switch"
-            aria-checked={imageConfig.partialImages > 0}
-            onClick={() =>
-              setImageConfig({
-                partialImages: imageConfig.partialImages > 0 ? 0 : LIVE_PREVIEW_PARTIAL_COUNT,
-              })
-            }
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-              imageConfig.partialImages > 0 ? 'bg-teal-600' : 'bg-gray-300'
-            }`}
+            aria-checked={false}
+            disabled
+            className="relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full bg-gray-200 opacity-60 cursor-not-allowed"
           >
-            <span
-              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
-                imageConfig.partialImages > 0 ? 'translate-x-5' : 'translate-x-0.5'
-              }`}
-            />
+            <span className="inline-block h-5 w-5 transform rounded-full bg-white shadow translate-x-0.5" />
           </button>
         </label>
       </div>

--- a/components/ui/SettingsPanel.tsx
+++ b/components/ui/SettingsPanel.tsx
@@ -3,6 +3,8 @@
 import { useAppStore } from '@/store/useAppStore';
 import React, { useState } from 'react';
 import { Button } from './Button';
+import { testConnection } from '@/lib/supabaseSync';
+import { toast } from 'sonner';
 
 interface SettingsPanelProps {
   isOpen: boolean;
@@ -10,9 +12,50 @@ interface SettingsPanelProps {
 }
 
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose }) => {
-  const { apiKey, setApiKey } = useAppStore();
+  const { apiKey, setApiKey, supabaseConfig, setSupabaseConfig } = useAppStore();
   const [newApiKey, setNewApiKey] = useState('');
   const [isEditing, setIsEditing] = useState(false);
+
+  const [supabaseUrl, setSupabaseUrl] = useState(supabaseConfig?.url ?? '');
+  const [supabaseKey, setSupabaseKey] = useState(supabaseConfig?.anonKey ?? '');
+  const [supabaseBucket, setSupabaseBucket] = useState(supabaseConfig?.bucket ?? 'sora');
+  const [testing, setTesting] = useState(false);
+
+  const handleTestSupabase = async () => {
+    if (!supabaseUrl.trim() || !supabaseKey.trim() || !supabaseBucket.trim()) {
+      toast.error('Fill URL, anon key and bucket first');
+      return;
+    }
+    setTesting(true);
+    const result = await testConnection({
+      url: supabaseUrl.trim(),
+      anonKey: supabaseKey.trim(),
+      bucket: supabaseBucket.trim(),
+    });
+    setTesting(false);
+    if (result.ok) toast.success('Supabase: ' + result.message);
+    else toast.error('Supabase: ' + result.message);
+  };
+
+  const handleSaveSupabase = () => {
+    if (!supabaseUrl.trim() || !supabaseKey.trim() || !supabaseBucket.trim()) {
+      toast.error('Fill URL, anon key and bucket first');
+      return;
+    }
+    setSupabaseConfig({
+      url: supabaseUrl.trim(),
+      anonKey: supabaseKey.trim(),
+      bucket: supabaseBucket.trim(),
+    });
+    toast.success('Cloud sync enabled');
+  };
+
+  const handleDisconnectSupabase = () => {
+    setSupabaseConfig(null);
+    setSupabaseUrl('');
+    setSupabaseKey('');
+    toast.success('Cloud sync disconnected');
+  };
 
   if (!isOpen) return null;
 
@@ -129,6 +172,77 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose })
                   Get your key here
                 </a>
               </p>
+            </div>
+
+            <div className="border-t pt-6">
+              <h3 className="text-sm font-medium text-gray-700 mb-1">Cloud Sync (Supabase)</h3>
+              <p className="text-xs text-gray-500 mb-3">
+                Optional. Uploads generated images to your own Supabase Storage bucket so they survive
+                device changes. Everything stays in your Supabase project —{' '}
+                <a
+                  href="https://supabase.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-teal-600 hover:text-teal-700 underline"
+                >
+                  create a free account
+                </a>
+                , make a Storage bucket, then paste your Project URL and anon key below.
+              </p>
+
+              {supabaseConfig ? (
+                <div className="space-y-3">
+                  <div className="bg-green-50 border border-green-200 px-3 py-2 rounded-lg text-xs text-green-800">
+                    Connected to <span className="font-semibold">{supabaseConfig.bucket}</span> at{' '}
+                    <span className="font-mono">{supabaseConfig.url.replace('https://', '')}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button variant="secondary" size="sm" onClick={handleTestSupabase} disabled={testing}>
+                      {testing ? 'Testing...' : 'Test connection'}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleDisconnectSupabase}
+                      className="text-red-600 hover:bg-red-50"
+                    >
+                      Disconnect
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  <input
+                    type="text"
+                    value={supabaseUrl}
+                    onChange={(e) => setSupabaseUrl(e.target.value)}
+                    placeholder="https://xxxxxxxx.supabase.co"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent text-sm"
+                  />
+                  <input
+                    type="password"
+                    value={supabaseKey}
+                    onChange={(e) => setSupabaseKey(e.target.value)}
+                    placeholder="anon public key"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent text-sm"
+                  />
+                  <input
+                    type="text"
+                    value={supabaseBucket}
+                    onChange={(e) => setSupabaseBucket(e.target.value)}
+                    placeholder="bucket name (e.g. sora)"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent text-sm"
+                  />
+                  <div className="flex gap-2">
+                    <Button variant="secondary" size="sm" onClick={handleTestSupabase} disabled={testing}>
+                      {testing ? 'Testing...' : 'Test connection'}
+                    </Button>
+                    <Button variant="primary" size="sm" onClick={handleSaveSupabase}>
+                      Save & enable
+                    </Button>
+                  </div>
+                </div>
+              )}
             </div>
 
             <div className="border-t pt-6">

--- a/components/ui/SettingsPanel.tsx
+++ b/components/ui/SettingsPanel.tsx
@@ -21,32 +21,37 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose })
   const [supabaseBucket, setSupabaseBucket] = useState(supabaseConfig?.bucket ?? 'sora');
   const [testing, setTesting] = useState(false);
 
+  // Strip all whitespace (JWT tokens break on any embedded space / newline).
+  const stripWhitespace = (s: string) => s.replace(/\s+/g, '');
+
   const handleTestSupabase = async () => {
-    if (!supabaseUrl.trim() || !supabaseKey.trim() || !supabaseBucket.trim()) {
+    const url = stripWhitespace(supabaseUrl);
+    const anonKey = stripWhitespace(supabaseKey);
+    const bucket = supabaseBucket.trim();
+    if (!url || !anonKey || !bucket) {
       toast.error('Fill URL, anon key and bucket first');
       return;
     }
     setTesting(true);
-    const result = await testConnection({
-      url: supabaseUrl.trim(),
-      anonKey: supabaseKey.trim(),
-      bucket: supabaseBucket.trim(),
-    });
+    const result = await testConnection({ url, anonKey, bucket });
     setTesting(false);
     if (result.ok) toast.success('Supabase: ' + result.message);
     else toast.error('Supabase: ' + result.message);
   };
 
   const handleSaveSupabase = () => {
-    if (!supabaseUrl.trim() || !supabaseKey.trim() || !supabaseBucket.trim()) {
+    const url = stripWhitespace(supabaseUrl);
+    const anonKey = stripWhitespace(supabaseKey);
+    const bucket = supabaseBucket.trim();
+    if (!url || !anonKey || !bucket) {
       toast.error('Fill URL, anon key and bucket first');
       return;
     }
-    setSupabaseConfig({
-      url: supabaseUrl.trim(),
-      anonKey: supabaseKey.trim(),
-      bucket: supabaseBucket.trim(),
-    });
+    setSupabaseConfig({ url, anonKey, bucket });
+    // Reflect cleaned values in the inputs so the user sees what was saved.
+    setSupabaseUrl(url);
+    setSupabaseKey(anonKey);
+    setSupabaseBucket(bucket);
     toast.success('Cloud sync enabled');
   };
 
@@ -135,6 +140,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose })
                     value={newApiKey}
                     onChange={(e) => setNewApiKey(e.target.value)}
                     placeholder="sk-..."
+                    autoComplete="new-password"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-form-type="other"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent"
                   />
                   <div className="flex gap-2">
@@ -217,6 +229,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose })
                     value={supabaseUrl}
                     onChange={(e) => setSupabaseUrl(e.target.value)}
                     placeholder="https://xxxxxxxx.supabase.co"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-form-type="other"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent text-sm"
                   />
                   <input
@@ -224,6 +243,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose })
                     value={supabaseKey}
                     onChange={(e) => setSupabaseKey(e.target.value)}
                     placeholder="anon public key"
+                    autoComplete="new-password"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-form-type="other"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent text-sm"
                   />
                   <input
@@ -231,6 +257,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ isOpen, onClose })
                     value={supabaseBucket}
                     onChange={(e) => setSupabaseBucket(e.target.value)}
                     placeholder="bucket name (e.g. sora)"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-form-type="other"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent text-sm"
                   />
                   <div className="flex gap-2">

--- a/lib/imagePricing.ts
+++ b/lib/imagePricing.ts
@@ -1,0 +1,56 @@
+// Per-image USD pricing as of 2026-04-18. Source: OpenAI pricing page.
+// Keys: model → quality → size → price per image in USD.
+const PRICING: Record<string, Record<string, Record<string, number>>> = {
+  'gpt-image-1.5': {
+    low: { '1024x1024': 0.009, '1024x1536': 0.013, '1536x1024': 0.013 },
+    medium: { '1024x1024': 0.034, '1024x1536': 0.05, '1536x1024': 0.05 },
+    high: { '1024x1024': 0.133, '1024x1536': 0.2, '1536x1024': 0.2 },
+  },
+  'gpt-image-1': {
+    low: { '1024x1024': 0.011, '1024x1536': 0.016, '1536x1024': 0.016 },
+    medium: { '1024x1024': 0.042, '1024x1536': 0.063, '1536x1024': 0.063 },
+    high: { '1024x1024': 0.167, '1024x1536': 0.25, '1536x1024': 0.25 },
+  },
+  'gpt-image-1-mini': {
+    low: { '1024x1024': 0.005, '1024x1536': 0.006, '1536x1024': 0.006 },
+    medium: { '1024x1024': 0.011, '1024x1536': 0.015, '1536x1024': 0.015 },
+    high: { '1024x1024': 0.036, '1024x1536': 0.052, '1536x1024': 0.052 },
+  },
+};
+
+// Auto falls back to medium quality when estimating cost.
+const AUTO_QUALITY_FALLBACK = 'medium';
+// Auto size falls back to the square resolution.
+const AUTO_SIZE_FALLBACK = '1024x1024';
+
+export interface ImageCostEstimate {
+  perImage: number;
+  total: number;
+  approximate: boolean;
+}
+
+export function estimateImageCost(params: {
+  model: string;
+  quality: string;
+  size: string;
+  n: number;
+}): ImageCostEstimate | null {
+  const resolvedQuality = params.quality === 'auto' ? AUTO_QUALITY_FALLBACK : params.quality;
+  const resolvedSize = params.size === 'auto' ? AUTO_SIZE_FALLBACK : params.size;
+  const approximate = params.quality === 'auto' || params.size === 'auto';
+
+  const perImage = PRICING[params.model]?.[resolvedQuality]?.[resolvedSize];
+  if (typeof perImage !== 'number') return null;
+
+  return {
+    perImage,
+    total: perImage * Math.max(params.n, 1),
+    approximate,
+  };
+}
+
+export function formatCost(usd: number): string {
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
+}

--- a/lib/imageStorage.ts
+++ b/lib/imageStorage.ts
@@ -1,0 +1,75 @@
+// Tiny IndexedDB wrapper for storing generated image data URLs.
+// Metadata stays in localStorage (via Zustand); the heavy base64 blobs live here.
+
+const DB_NAME = 'sora-studio';
+const DB_VERSION = 1;
+const STORE = 'images';
+
+type DBValue = { id: string; dataUrl: string };
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDB(): Promise<IDBDatabase> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('IndexedDB only available in the browser'));
+  }
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE)) {
+          db.createObjectStore(STORE, { keyPath: 'id' });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+  return dbPromise;
+}
+
+export async function putImage(id: string, dataUrl: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).put({ id, dataUrl } satisfies DBValue);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getImage(id: string): Promise<string | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).get(id);
+    req.onsuccess = () => {
+      const value = req.result as DBValue | undefined;
+      resolve(value?.dataUrl ?? null);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function deleteImage(id: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function deleteImages(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    const store = tx.objectStore(STORE);
+    for (const id of ids) store.delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/lib/supabaseSync.ts
+++ b/lib/supabaseSync.ts
@@ -1,0 +1,76 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+export interface SupabaseConfig {
+  url: string;
+  anonKey: string;
+  bucket: string;
+}
+
+let cachedClient: SupabaseClient | null = null;
+let cachedConfigKey: string | null = null;
+
+function clientKey(config: SupabaseConfig): string {
+  return `${config.url}|${config.anonKey}`;
+}
+
+export function getSupabaseClient(config: SupabaseConfig | null): SupabaseClient | null {
+  if (!config?.url || !config?.anonKey) return null;
+  const key = clientKey(config);
+  if (cachedClient && cachedConfigKey === key) return cachedClient;
+  cachedClient = createClient(config.url, config.anonKey, {
+    auth: { persistSession: false },
+  });
+  cachedConfigKey = key;
+  return cachedClient;
+}
+
+async function dataUrlToBlob(dataUrl: string): Promise<Blob> {
+  const response = await fetch(dataUrl);
+  return response.blob();
+}
+
+export async function uploadImage(
+  config: SupabaseConfig,
+  path: string,
+  dataUrl: string,
+): Promise<string> {
+  const client = getSupabaseClient(config);
+  if (!client) throw new Error('Supabase not configured');
+
+  const blob = await dataUrlToBlob(dataUrl);
+  const { error } = await client.storage
+    .from(config.bucket)
+    .upload(path, blob, {
+      contentType: 'image/png',
+      upsert: false,
+    });
+
+  if (error) throw new Error(error.message);
+
+  const { data } = client.storage.from(config.bucket).getPublicUrl(path);
+  return data.publicUrl;
+}
+
+export async function removeImage(config: SupabaseConfig, path: string): Promise<void> {
+  const client = getSupabaseClient(config);
+  if (!client) return;
+  await client.storage.from(config.bucket).remove([path]);
+}
+
+export async function testConnection(config: SupabaseConfig): Promise<{ ok: boolean; message: string }> {
+  try {
+    const client = getSupabaseClient(config);
+    if (!client) return { ok: false, message: 'Missing URL or key' };
+
+    const { error } = await client.storage.from(config.bucket).list('', { limit: 1 });
+    if (error) return { ok: false, message: error.message };
+    return { ok: true, message: 'Connected' };
+  } catch (err: any) {
+    return { ok: false, message: err?.message || 'Connection failed' };
+  }
+}
+
+// Path inside the bucket.
+export function imagePathFor(groupId: string, indexInGroup: number): string {
+  return `${groupId}/${indexInGroup}.png`;
+}

--- a/lib/useImageGeneration.ts
+++ b/lib/useImageGeneration.ts
@@ -26,19 +26,20 @@ async function previewUrlToBase64(url: string): Promise<string> {
 }
 
 export function useImageGeneration() {
-  const {
-    apiKey,
-    chatMessages,
-    baseImage,
-    imageConfig,
-    updateImageGeneration,
-    resetImageGeneration,
-    saveImageGroup,
-    addChatMessage,
-    saveCurrentConversation,
-  } = useAppStore();
-
   const generateImages = useCallback(async () => {
+    const state = useAppStore.getState();
+    const {
+      apiKey,
+      chatMessages,
+      baseImage,
+      imageConfig,
+      updateImageGeneration,
+      resetImageGeneration,
+      saveImageGroup,
+      addChatMessage,
+      saveCurrentConversation,
+    } = state;
+
     if (!apiKey) {
       toast.error('Please set your OpenAI API key in settings');
       return;
@@ -169,17 +170,7 @@ export function useImageGeneration() {
       });
       updateImageGeneration({ status: 'failed', error: errorMessage, errorCode });
     }
-  }, [
-    apiKey,
-    chatMessages,
-    baseImage,
-    imageConfig,
-    updateImageGeneration,
-    resetImageGeneration,
-    saveImageGroup,
-    addChatMessage,
-    saveCurrentConversation,
-  ]);
+  }, []);
 
   return { generateImages };
 }

--- a/lib/useImageGeneration.ts
+++ b/lib/useImageGeneration.ts
@@ -82,6 +82,7 @@ export function useImageGeneration() {
           type: 'generation',
           status: 'started',
           title,
+          mediaType: 'image',
         },
       });
 
@@ -203,7 +204,7 @@ async function runBatch(params: {
     role: 'info',
     content: `Generated ${images.length} image${images.length > 1 ? 's' : ''}: "${title}".`,
     imageIds,
-    metadata: { type: 'generation', status: 'completed', title },
+    metadata: { type: 'generation', status: 'completed', title, mediaType: 'image' },
   });
 
   saveCurrentConversation();
@@ -340,7 +341,7 @@ async function runStreaming(params: {
     role: 'info',
     content: `Generated ${completed.length} image${completed.length > 1 ? 's' : ''}: "${title}".`,
     imageIds,
-    metadata: { type: 'generation', status: 'completed', title },
+    metadata: { type: 'generation', status: 'completed', title, mediaType: 'image' },
   });
 
   saveCurrentConversation();

--- a/lib/useImageGeneration.ts
+++ b/lib/useImageGeneration.ts
@@ -25,6 +25,10 @@ async function previewUrlToBase64(url: string): Promise<string> {
   return btoa(binary);
 }
 
+function b64ToDataUrl(b64: string): string {
+  return b64.startsWith('data:') ? b64 : `data:image/png;base64,${b64}`;
+}
+
 export function useImageGeneration() {
   const generateImages = useCallback(async () => {
     const state = useAppStore.getState();
@@ -59,9 +63,17 @@ export function useImageGeneration() {
     const title =
       prompt.trim().split(/\s+/).slice(0, 8).join(' ').slice(0, 80) || 'Untitled Image';
 
+    const useStream = imageConfig.partialImages > 0;
+
     try {
       resetImageGeneration();
-      updateImageGeneration({ status: 'generating', error: null });
+      updateImageGeneration({
+        status: 'generating',
+        error: null,
+        startedAt: Date.now(),
+        partialPreviews: Array(imageConfig.n).fill(null),
+        activeIndex: 0,
+      });
 
       addChatMessage({
         role: 'info',
@@ -87,70 +99,22 @@ export function useImageGeneration() {
         }
       }
 
-      const response = await apiCall(
-        '/api/images/create',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            prompt,
-            n: imageConfig.n,
-            size: imageConfig.size,
-            quality: imageConfig.quality,
-            model: imageConfig.model,
-            inputImageBase64,
-          }),
-        },
-        apiKey,
-      );
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        const errorMessage = data.error?.message || data.error || 'Failed to generate images';
-        const errorCode = data.error?.code || 'image_generation_failed';
-
-        toast.error(errorMessage);
-        addChatMessage({
-          role: 'error',
-          content: errorMessage,
-          errorMetadata: { code: errorCode },
-        });
-
-        updateImageGeneration({ status: 'failed', error: errorMessage, errorCode });
-        return;
-      }
-
-      const images: string[] = data.images || [];
-      if (images.length === 0) {
-        const msg = 'No images returned by the API';
-        toast.error(msg);
-        addChatMessage({ role: 'error', content: msg, errorMetadata: { code: 'empty_response' } });
-        updateImageGeneration({ status: 'failed', error: msg });
-        return;
-      }
-
-      saveCurrentConversation();
-      const imageIds = saveImageGroup(images, prompt, title, {
-        model: data.model || imageConfig.model,
-        size: data.size || imageConfig.size,
-        quality: data.quality || imageConfig.quality,
-        hadBaseImage: Boolean(inputImageBase64),
-      });
-
-      addChatMessage({
-        role: 'info',
-        content: `Generated ${images.length} image${images.length > 1 ? 's' : ''}: "${title}".`,
-        imageIds,
-        metadata: {
-          type: 'generation',
-          status: 'completed',
+      if (useStream && !inputImageBase64) {
+        await runStreaming({
+          apiKey,
+          prompt,
           title,
-        },
-      });
-
-      saveCurrentConversation();
-      updateImageGeneration({ status: 'completed' });
+          imageConfig,
+        });
+      } else {
+        await runBatch({
+          apiKey,
+          prompt,
+          title,
+          imageConfig,
+          inputImageBase64,
+        });
+      }
     } catch (error) {
       let errorMessage = 'Unknown error occurred';
       let errorCode = 'unknown_error';
@@ -173,4 +137,212 @@ export function useImageGeneration() {
   }, []);
 
   return { generateImages };
+}
+
+async function runBatch(params: {
+  apiKey: string;
+  prompt: string;
+  title: string;
+  imageConfig: ReturnType<typeof useAppStore.getState>['imageConfig'];
+  inputImageBase64: string | null;
+}) {
+  const { apiKey, prompt, title, imageConfig, inputImageBase64 } = params;
+  const {
+    updateImageGeneration,
+    saveImageGroup,
+    addChatMessage,
+    saveCurrentConversation,
+  } = useAppStore.getState();
+
+  const response = await apiCall(
+    '/api/images/create',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt,
+        n: imageConfig.n,
+        size: imageConfig.size,
+        quality: imageConfig.quality,
+        model: imageConfig.model,
+        inputImageBase64,
+      }),
+    },
+    apiKey,
+  );
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    const errorMessage = data.error?.message || data.error || 'Failed to generate images';
+    const errorCode = data.error?.code || 'image_generation_failed';
+    toast.error(errorMessage);
+    addChatMessage({ role: 'error', content: errorMessage, errorMetadata: { code: errorCode } });
+    updateImageGeneration({ status: 'failed', error: errorMessage, errorCode });
+    return;
+  }
+
+  const images: string[] = data.images || [];
+  if (images.length === 0) {
+    const msg = 'No images returned by the API';
+    toast.error(msg);
+    addChatMessage({ role: 'error', content: msg, errorMetadata: { code: 'empty_response' } });
+    updateImageGeneration({ status: 'failed', error: msg });
+    return;
+  }
+
+  saveCurrentConversation();
+  const imageIds = saveImageGroup(images, prompt, title, {
+    model: data.model || imageConfig.model,
+    size: data.size || imageConfig.size,
+    quality: data.quality || imageConfig.quality,
+    hadBaseImage: Boolean(inputImageBase64),
+  });
+
+  addChatMessage({
+    role: 'info',
+    content: `Generated ${images.length} image${images.length > 1 ? 's' : ''}: "${title}".`,
+    imageIds,
+    metadata: { type: 'generation', status: 'completed', title },
+  });
+
+  saveCurrentConversation();
+  updateImageGeneration({ status: 'completed' });
+}
+
+async function runStreaming(params: {
+  apiKey: string;
+  prompt: string;
+  title: string;
+  imageConfig: ReturnType<typeof useAppStore.getState>['imageConfig'];
+}) {
+  const { apiKey, prompt, title, imageConfig } = params;
+  const {
+    updateImageGeneration,
+    saveImageGroup,
+    addChatMessage,
+    saveCurrentConversation,
+  } = useAppStore.getState();
+
+  const response = await fetch('/api/images/generate-stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+    body: JSON.stringify({
+      prompt,
+      n: imageConfig.n,
+      size: imageConfig.size,
+      quality: imageConfig.quality,
+      partialImages: imageConfig.partialImages,
+    }),
+  });
+
+  if (!response.ok || !response.body) {
+    const data = await response.json().catch(() => ({ error: 'Streaming failed' }));
+    const errorMessage = data.error?.message || data.error || 'Streaming failed';
+    const errorCode = data.error?.code || 'stream_failed';
+    toast.error(errorMessage);
+    addChatMessage({ role: 'error', content: errorMessage, errorMetadata: { code: errorCode } });
+    updateImageGeneration({ status: 'failed', error: errorMessage, errorCode });
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const finals: string[] = new Array(imageConfig.n).fill('');
+  let streamError: { message: string; code?: string } | null = null as { message: string; code?: string } | null;
+
+  const applyEvent = (payload: any) => {
+    if (!payload || typeof payload !== 'object') return;
+    switch (payload.kind) {
+      case 'image_started': {
+        updateImageGeneration({ activeIndex: payload.index });
+        break;
+      }
+      case 'partial': {
+        const { partialPreviews } = useAppStore.getState().imageGeneration;
+        const next = [...partialPreviews];
+        next[payload.index] = b64ToDataUrl(payload.b64);
+        updateImageGeneration({ partialPreviews: next, activeIndex: payload.index });
+        break;
+      }
+      case 'final': {
+        const dataUrl = b64ToDataUrl(payload.b64);
+        finals[payload.index] = dataUrl;
+        const { partialPreviews } = useAppStore.getState().imageGeneration;
+        const next = [...partialPreviews];
+        next[payload.index] = dataUrl;
+        updateImageGeneration({ partialPreviews: next });
+        break;
+      }
+      case 'error': {
+        streamError = { message: payload.message, code: payload.code };
+        break;
+      }
+      case 'done':
+      default:
+        break;
+    }
+  };
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('data:')) continue;
+      const jsonStr = trimmed.slice(5).trim();
+      if (!jsonStr) continue;
+      try {
+        applyEvent(JSON.parse(jsonStr));
+      } catch {
+        // ignore malformed line
+      }
+    }
+  }
+
+  if (streamError) {
+    toast.error(streamError.message);
+    addChatMessage({
+      role: 'error',
+      content: streamError.message,
+      errorMetadata: { code: streamError.code || 'stream_error' },
+    });
+    updateImageGeneration({
+      status: 'failed',
+      error: streamError.message,
+      errorCode: streamError.code,
+    });
+    return;
+  }
+
+  const completed = finals.filter(Boolean);
+  if (completed.length === 0) {
+    const msg = 'No images returned from stream';
+    toast.error(msg);
+    addChatMessage({ role: 'error', content: msg, errorMetadata: { code: 'empty_response' } });
+    updateImageGeneration({ status: 'failed', error: msg });
+    return;
+  }
+
+  saveCurrentConversation();
+  const imageIds = saveImageGroup(completed, prompt, title, {
+    model: imageConfig.model,
+    size: imageConfig.size,
+    quality: imageConfig.quality,
+    hadBaseImage: false,
+  });
+
+  addChatMessage({
+    role: 'info',
+    content: `Generated ${completed.length} image${completed.length > 1 ? 's' : ''}: "${title}".`,
+    imageIds,
+    metadata: { type: 'generation', status: 'completed', title },
+  });
+
+  saveCurrentConversation();
+  updateImageGeneration({ status: 'completed' });
 }

--- a/lib/useImageGeneration.ts
+++ b/lib/useImageGeneration.ts
@@ -1,0 +1,185 @@
+import { useCallback } from 'react';
+import { useAppStore } from '@/store/useAppStore';
+import { apiCall } from './api';
+import { toast } from 'sonner';
+
+async function fileToBase64(file: File): Promise<string> {
+  const arrayBuffer = await file.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+async function previewUrlToBase64(url: string): Promise<string> {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  const buffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export function useImageGeneration() {
+  const {
+    apiKey,
+    chatMessages,
+    baseImage,
+    imageConfig,
+    updateImageGeneration,
+    resetImageGeneration,
+    saveImageGroup,
+    addChatMessage,
+    saveCurrentConversation,
+  } = useAppStore();
+
+  const generateImages = useCallback(async () => {
+    if (!apiKey) {
+      toast.error('Please set your OpenAI API key in settings');
+      return;
+    }
+
+    const userMessages = chatMessages
+      .filter((msg) => msg.role === 'user')
+      .map((msg) => msg.content)
+      .join(' ');
+
+    if (!userMessages.trim()) {
+      toast.error('Please describe the image you want in the chat');
+      return;
+    }
+
+    const prompt = userMessages;
+    const title =
+      prompt.trim().split(/\s+/).slice(0, 8).join(' ').slice(0, 80) || 'Untitled Image';
+
+    try {
+      resetImageGeneration();
+      updateImageGeneration({ status: 'generating', error: null });
+
+      addChatMessage({
+        role: 'info',
+        content: `Generating ${imageConfig.n} image${imageConfig.n > 1 ? 's' : ''}: "${title}".`,
+        metadata: {
+          type: 'generation',
+          status: 'started',
+          title,
+        },
+      });
+
+      let inputImageBase64: string | null = null;
+      if (baseImage) {
+        try {
+          if (baseImage.file) {
+            inputImageBase64 = await fileToBase64(baseImage.file);
+          } else if (baseImage.previewUrl) {
+            inputImageBase64 = await previewUrlToBase64(baseImage.previewUrl);
+          }
+        } catch (err) {
+          console.error('Failed to prepare base image:', err);
+          toast.warning('Failed to use base image. Continuing without it.');
+        }
+      }
+
+      const response = await apiCall(
+        '/api/images/create',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            prompt,
+            n: imageConfig.n,
+            size: imageConfig.size,
+            quality: imageConfig.quality,
+            model: imageConfig.model,
+            inputImageBase64,
+          }),
+        },
+        apiKey,
+      );
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        const errorMessage = data.error?.message || data.error || 'Failed to generate images';
+        const errorCode = data.error?.code || 'image_generation_failed';
+
+        toast.error(errorMessage);
+        addChatMessage({
+          role: 'error',
+          content: errorMessage,
+          errorMetadata: { code: errorCode },
+        });
+
+        updateImageGeneration({ status: 'failed', error: errorMessage, errorCode });
+        return;
+      }
+
+      const images: string[] = data.images || [];
+      if (images.length === 0) {
+        const msg = 'No images returned by the API';
+        toast.error(msg);
+        addChatMessage({ role: 'error', content: msg, errorMetadata: { code: 'empty_response' } });
+        updateImageGeneration({ status: 'failed', error: msg });
+        return;
+      }
+
+      saveCurrentConversation();
+      const imageIds = saveImageGroup(images, prompt, title, {
+        model: data.model || imageConfig.model,
+        size: data.size || imageConfig.size,
+        quality: data.quality || imageConfig.quality,
+        hadBaseImage: Boolean(inputImageBase64),
+      });
+
+      addChatMessage({
+        role: 'info',
+        content: `Generated ${images.length} image${images.length > 1 ? 's' : ''}: "${title}".`,
+        imageIds,
+        metadata: {
+          type: 'generation',
+          status: 'completed',
+          title,
+        },
+      });
+
+      saveCurrentConversation();
+      updateImageGeneration({ status: 'completed' });
+    } catch (error) {
+      let errorMessage = 'Unknown error occurred';
+      let errorCode = 'unknown_error';
+      try {
+        const parsed = JSON.parse((error as Error).message);
+        errorMessage = parsed.message || errorMessage;
+        errorCode = parsed.code || errorCode;
+      } catch {
+        errorMessage = (error as Error).message || errorMessage;
+      }
+
+      toast.error(errorMessage);
+      addChatMessage({
+        role: 'error',
+        content: errorMessage,
+        errorMetadata: { code: errorCode },
+      });
+      updateImageGeneration({ status: 'failed', error: errorMessage, errorCode });
+    }
+  }, [
+    apiKey,
+    chatMessages,
+    baseImage,
+    imageConfig,
+    updateImageGeneration,
+    resetImageGeneration,
+    saveImageGroup,
+    addChatMessage,
+    saveCurrentConversation,
+  ]);
+
+  return { generateImages };
+}

--- a/lib/videoPricing.ts
+++ b/lib/videoPricing.ts
@@ -1,0 +1,40 @@
+// Per-second USD pricing as of 2026-04-18. Source: OpenAI model pages.
+// Keys: model → size → price per second in USD.
+const PRICING: Record<string, Record<string, number>> = {
+  'sora-2': {
+    '1280x720': 0.1,
+    '720x1280': 0.1,
+  },
+  'sora-2-pro': {
+    '1280x720': 0.3,
+    '720x1280': 0.3,
+    '1792x1024': 0.5,
+    '1024x1792': 0.5,
+    '1920x1080': 0.7,
+    '1080x1920': 0.7,
+  },
+};
+
+export interface VideoCostEstimate {
+  perSecond: number;
+  seconds: number;
+  total: number;
+}
+
+export function estimateVideoCost(params: {
+  model: string;
+  size: string;
+  seconds: string | number;
+}): VideoCostEstimate | null {
+  const perSecond = PRICING[params.model]?.[params.size];
+  if (typeof perSecond !== 'number') return null;
+
+  const seconds = typeof params.seconds === 'string' ? Number(params.seconds) : params.seconds;
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+
+  return {
+    perSecond,
+    seconds,
+    total: perSecond * seconds,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@supabase/supabase-js": "^2.103.3",
         "@types/node": "^24.7.0",
         "@types/react": "^19.2.1",
         "@types/react-dom": "^19.2.0",
@@ -764,6 +765,92 @@
         "node": ">=14"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.3.tgz",
+      "integrity": "sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.3.tgz",
+      "integrity": "sha512-A2ZHi95GIRRlN9LGOSa/zGEIPg9taR1giDI9Gkfkgrcz0YmKV8ShiAplIrKsHQFdkzKxtsO3maJF0efL+i31mg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.3.tgz",
+      "integrity": "sha512-S0k/9FJVXDeejNfQLCJwRlm4IH8Wet/HEEdBTBpX6/G2o1eU/6CjQop/hJPZIwlQkI6D/zbHH8KymuCsBgy6jA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.3.tgz",
+      "integrity": "sha512-fUvKtSXMUk1BkApVwAurWtHF4Vzbb0UB9aC/fQXrRBek7Ta3Kaora+wHf/fGwFNQs7uRz+mvjIVpzLfpR32VXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.3.tgz",
+      "integrity": "sha512-5bAIEubrw5keHcdKR2RTois0O1M2Ilx4UYuzOzc07G6mLGCPS/8t1nbC6Vq451pnxR3sK+rmtFHWb9CY/OPjAw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.3.tgz",
+      "integrity": "sha512-DuPiAz5pIJsTAQCt7B6bDZrnLzlq9+/5bta/GWTsgpLn6AkuZQcmYsQHYplv4skQ8U2raKY5HASQOu4KtYq9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.103.3",
+        "@supabase/functions-js": "2.103.3",
+        "@supabase/postgrest-js": "2.103.3",
+        "@supabase/realtime-js": "2.103.3",
+        "@supabase/storage-js": "2.103.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -798,6 +885,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vercel/analytics": {
@@ -1333,6 +1429,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/immediate": {
@@ -2621,6 +2726,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@supabase/supabase-js": "^2.103.3",
     "@types/node": "^24.7.0",
     "@types/react": "^19.2.1",
     "@types/react-dom": "^19.2.0",

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -78,12 +78,16 @@ export interface ImageConfig {
   size: string;
   quality: string;
   model: string;
+  partialImages: 0 | 1 | 2 | 3;
 }
 
 export interface ImageGeneration {
   status: 'idle' | 'generating' | 'completed' | 'failed';
   error: string | null;
   errorCode?: string | null;
+  startedAt: number | null;
+  partialPreviews: (string | null)[];
+  activeIndex: number;
 }
 
 export type GenerationMode = 'video' | 'image';
@@ -200,6 +204,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     size: '1024x1024',
     quality: 'auto',
     model: 'gpt-image-1.5',
+    partialImages: 0,
   },
   setImageConfig: (config) => {
     const newConfig = { ...get().imageConfig, ...config };
@@ -295,6 +300,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   imageGeneration: {
     status: 'idle',
     error: null,
+    startedAt: null,
+    partialPreviews: [],
+    activeIndex: 0,
   },
   updateImageGeneration: (updates) =>
     set((state) => ({
@@ -302,7 +310,13 @@ export const useAppStore = create<AppState>((set, get) => ({
     })),
   resetImageGeneration: () =>
     set({
-      imageGeneration: { status: 'idle', error: null },
+      imageGeneration: {
+        status: 'idle',
+        error: null,
+        startedAt: null,
+        partialPreviews: [],
+        activeIndex: 0,
+      },
     }),
 
   // Conversation History

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { putImage, getImage, deleteImage as deleteImageFromIDB, deleteImages as deleteImagesFromIDB } from '@/lib/imageStorage';
+import { uploadImage as uploadImageToSupabase, removeImage as removeImageFromSupabase, imagePathFor } from '@/lib/supabaseSync';
 
 export type InfoMessageType = 'generation' | 'remix_reference';
 
@@ -60,6 +61,8 @@ export interface SavedImage {
   prompt: string;
   title: string;
   dataUrl: string;
+  cloudUrl?: string;
+  cloudPath?: string;
   createdAt: number;
   model: string;
   size: string;
@@ -67,6 +70,12 @@ export interface SavedImage {
   groupId: string;
   indexInGroup: number;
   hadBaseImage: boolean;
+}
+
+export interface SupabaseConfigState {
+  url: string;
+  anonKey: string;
+  bucket: string;
 }
 
 export interface VideoConfig {
@@ -113,6 +122,11 @@ interface AppState {
   // Image Configuration
   imageConfig: ImageConfig;
   setImageConfig: (config: Partial<ImageConfig>) => void;
+
+  // Supabase Cloud Sync (optional)
+  supabaseConfig: SupabaseConfigState | null;
+  setSupabaseConfig: (config: SupabaseConfigState | null) => void;
+  updateSavedImage: (id: string, patch: Partial<SavedImage>) => void;
 
   // Base Image
   baseImage: { file?: File; previewUrl: string; cropX?: number; cropY?: number } | null;
@@ -221,6 +235,23 @@ export const useAppStore = create<AppState>((set, get) => ({
     const newConfig = { ...get().imageConfig, ...config };
     localStorage.setItem('image_config', JSON.stringify(newConfig));
     set({ imageConfig: newConfig });
+  },
+
+  // Supabase Cloud Sync
+  supabaseConfig: null,
+  setSupabaseConfig: (config) => {
+    if (config) {
+      localStorage.setItem('supabase_config', JSON.stringify(config));
+    } else {
+      localStorage.removeItem('supabase_config');
+    }
+    set({ supabaseConfig: config });
+  },
+  updateSavedImage: (id, patch) => {
+    const state = get();
+    const updated = state.savedImages.map((img) => (img.id === id ? { ...img, ...patch } : img));
+    persistSavedImagesMeta(updated);
+    set({ savedImages: updated });
   },
 
   // Base Image
@@ -438,15 +469,32 @@ export const useAppStore = create<AppState>((set, get) => ({
     persistSavedImagesMeta(updated);
     set({ savedImages: updated });
 
+    // Optional: sync to Supabase in background.
+    const supabase = state.supabaseConfig;
+    if (supabase?.url && supabase?.anonKey && supabase?.bucket) {
+      for (const entry of entries) {
+        const path = imagePathFor(entry.groupId, entry.indexInGroup);
+        uploadImageToSupabase(supabase, path, entry.dataUrl)
+          .then((cloudUrl) => get().updateSavedImage(entry.id, { cloudUrl, cloudPath: path }))
+          .catch((err) => console.error('Supabase upload failed:', err));
+      }
+    }
+
     return entries.map((e) => e.id);
   },
 
   deleteImage: (id) => {
     const state = get();
+    const target = state.savedImages.find((img) => img.id === id);
     const updated = state.savedImages.filter((img) => img.id !== id);
     persistSavedImagesMeta(updated);
     set({ savedImages: updated });
     deleteImageFromIDB(id).catch((err) => console.error('Failed to delete image from IDB:', err));
+    if (target?.cloudPath && state.supabaseConfig) {
+      removeImageFromSupabase(state.supabaseConfig, target.cloudPath).catch((err) =>
+        console.error('Failed to delete image from Supabase:', err),
+      );
+    }
   },
 
   saveVideo: (videoId, prompt, title, remixedFromVideoId = null) => {
@@ -582,5 +630,17 @@ if (typeof window !== 'undefined') {
   const storedGenerationMode = localStorage.getItem('generation_mode') as GenerationMode | null;
   if (storedGenerationMode === 'video' || storedGenerationMode === 'image') {
     useAppStore.setState({ generationMode: storedGenerationMode });
+  }
+
+  const storedSupabase = localStorage.getItem('supabase_config');
+  if (storedSupabase) {
+    try {
+      const parsed = JSON.parse(storedSupabase);
+      if (parsed?.url && parsed?.anonKey && parsed?.bucket) {
+        useAppStore.setState({ supabaseConfig: parsed });
+      }
+    } catch (e) {
+      console.error('Failed to parse supabase config');
+    }
   }
 }

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -9,6 +9,7 @@ export interface InfoMessageMetadata {
   status?: 'started' | 'completed';
   title?: string;
   isRemix?: boolean;
+  mediaType?: 'video' | 'image';
 }
 
 export interface ErrorMetadata {

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -19,6 +19,7 @@ export interface ChatMessage {
   content: string;
   timestamp: number;
   videoId?: string | null;
+  imageIds?: string[] | null;
   metadata?: InfoMessageMetadata;
   errorMetadata?: ErrorMetadata;
 }
@@ -52,10 +53,40 @@ export interface SavedVideo {
   remixedFromVideoId?: string | null;
 }
 
+export interface SavedImage {
+  id: string;
+  conversationId: string | null;
+  prompt: string;
+  title: string;
+  dataUrl: string;
+  createdAt: number;
+  model: string;
+  size: string;
+  quality: string;
+  groupId: string;
+  indexInGroup: number;
+  hadBaseImage: boolean;
+}
+
 export interface VideoConfig {
   size: string;
   seconds: string;
 }
+
+export interface ImageConfig {
+  n: number;
+  size: string;
+  quality: string;
+  model: string;
+}
+
+export interface ImageGeneration {
+  status: 'idle' | 'generating' | 'completed' | 'failed';
+  error: string | null;
+  errorCode?: string | null;
+}
+
+export type GenerationMode = 'video' | 'image';
 
 interface AppState {
   // API Key
@@ -66,9 +97,17 @@ interface AppState {
   selectedModel: 'sora-2' | 'sora-2-pro';
   setSelectedModel: (model: 'sora-2' | 'sora-2-pro') => void;
 
+  // Generation Mode (video vs image)
+  generationMode: GenerationMode;
+  setGenerationMode: (mode: GenerationMode) => void;
+
   // Video Configuration
   videoConfig: VideoConfig;
   setVideoConfig: (config: Partial<VideoConfig>) => void;
+
+  // Image Configuration
+  imageConfig: ImageConfig;
+  setImageConfig: (config: Partial<ImageConfig>) => void;
 
   // Base Image
   baseImage: { file?: File; previewUrl: string; cropX?: number; cropY?: number } | null;
@@ -97,14 +136,22 @@ interface AppState {
   updateVideoGeneration: (updates: Partial<VideoGeneration>) => void;
   resetVideoGeneration: () => void;
 
+  // Image Generation
+  imageGeneration: ImageGeneration;
+  updateImageGeneration: (updates: Partial<ImageGeneration>) => void;
+  resetImageGeneration: () => void;
+
   // Conversation History
   currentConversationId: string | null;
   savedConversations: SavedConversation[];
   savedVideos: SavedVideo[];
+  savedImages: SavedImage[];
   saveCurrentConversation: () => void;
   loadConversation: (id: string) => void;
   deleteConversation: (id: string) => void;
   saveVideo: (videoId: string, prompt: string, title: string, remixedFromVideoId?: string | null) => void;
+  saveImageGroup: (images: string[], prompt: string, title: string, meta: { model: string; size: string; quality: string; hadBaseImage: boolean }) => string[];
+  deleteImage: (id: string) => void;
   newConversation: () => void;
 }
 
@@ -127,6 +174,13 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ selectedModel: model });
   },
 
+  // Generation Mode
+  generationMode: 'video',
+  setGenerationMode: (mode) => {
+    localStorage.setItem('generation_mode', mode);
+    set({ generationMode: mode });
+  },
+
   // Video Configuration
   videoConfig: {
     size: '1280x720',
@@ -136,6 +190,19 @@ export const useAppStore = create<AppState>((set, get) => ({
     const newConfig = { ...get().videoConfig, ...config };
     localStorage.setItem('video_config', JSON.stringify(newConfig));
     set({ videoConfig: newConfig });
+  },
+
+  // Image Configuration
+  imageConfig: {
+    n: 1,
+    size: '1024x1024',
+    quality: 'auto',
+    model: 'gpt-image-1.5',
+  },
+  setImageConfig: (config) => {
+    const newConfig = { ...get().imageConfig, ...config };
+    localStorage.setItem('image_config', JSON.stringify(newConfig));
+    set({ imageConfig: newConfig });
   },
 
   // Base Image
@@ -220,10 +287,25 @@ export const useAppStore = create<AppState>((set, get) => ({
       },
     }),
 
+  // Image Generation
+  imageGeneration: {
+    status: 'idle',
+    error: null,
+  },
+  updateImageGeneration: (updates) =>
+    set((state) => ({
+      imageGeneration: { ...state.imageGeneration, ...updates },
+    })),
+  resetImageGeneration: () =>
+    set({
+      imageGeneration: { status: 'idle', error: null },
+    }),
+
   // Conversation History
   currentConversationId: null,
   savedConversations: [],
   savedVideos: [],
+  savedImages: [],
 
   saveCurrentConversation: () => {
     const state = get();
@@ -284,6 +366,41 @@ export const useAppStore = create<AppState>((set, get) => ({
       savedConversations: updatedConversations,
       savedVideos: updatedVideos,
     });
+  },
+
+  saveImageGroup: (images, prompt, title, meta) => {
+    const state = get();
+    const groupId = `img-grp-${Date.now()}`;
+    const createdAt = Date.now();
+    const conversationId = state.currentConversationId;
+
+    const entries: SavedImage[] = images.map((dataUrl, index) => ({
+      id: `img-${createdAt}-${index}`,
+      conversationId,
+      prompt,
+      title,
+      dataUrl,
+      createdAt,
+      model: meta.model,
+      size: meta.size,
+      quality: meta.quality,
+      groupId,
+      indexInGroup: index,
+      hadBaseImage: meta.hadBaseImage,
+    }));
+
+    const updated = [...entries, ...state.savedImages];
+    localStorage.setItem('saved_images', JSON.stringify(updated));
+    set({ savedImages: updated });
+
+    return entries.map((e) => e.id);
+  },
+
+  deleteImage: (id) => {
+    const state = get();
+    const updated = state.savedImages.filter((img) => img.id !== id);
+    localStorage.setItem('saved_images', JSON.stringify(updated));
+    set({ savedImages: updated });
   },
 
   saveVideo: (videoId, prompt, title, remixedFromVideoId = null) => {
@@ -370,5 +487,29 @@ if (typeof window !== 'undefined') {
     } catch (e) {
       console.error('Failed to parse saved videos');
     }
+  }
+
+  const storedImages = localStorage.getItem('saved_images');
+  if (storedImages) {
+    try {
+      useAppStore.setState({ savedImages: JSON.parse(storedImages) });
+    } catch (e) {
+      console.error('Failed to parse saved images');
+    }
+  }
+
+  const storedImageConfig = localStorage.getItem('image_config');
+  if (storedImageConfig) {
+    try {
+      const parsed = JSON.parse(storedImageConfig);
+      useAppStore.setState((state) => ({ imageConfig: { ...state.imageConfig, ...parsed } }));
+    } catch (e) {
+      console.error('Failed to parse image config');
+    }
+  }
+
+  const storedGenerationMode = localStorage.getItem('generation_mode') as GenerationMode | null;
+  if (storedGenerationMode === 'video' || storedGenerationMode === 'image') {
+    useAppStore.setState({ generationMode: storedGenerationMode });
   }
 }

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -282,16 +282,19 @@ export const useAppStore = create<AppState>((set, get) => ({
     },
   ],
   addChatMessage: (message) =>
-    set((state) => ({
-      chatMessages: [
-        ...state.chatMessages,
-        {
-          ...message,
-          id: `msg-${Date.now()}`,
-          timestamp: Date.now(),
-        },
-      ],
-    })),
+    set((state) => {
+      const now = Date.now();
+      return {
+        chatMessages: [
+          ...state.chatMessages,
+          {
+            ...message,
+            id: `msg-${now}-${Math.random().toString(36).slice(2, 8)}`,
+            timestamp: now,
+          },
+        ],
+      };
+    }),
   readyToGenerate: false,
   setReadyToGenerate: (ready) => set({ readyToGenerate: ready }),
   remixReference: null,

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { putImage, getImage, deleteImage as deleteImageFromIDB, deleteImages as deleteImagesFromIDB } from '@/lib/imageStorage';
 
 export type InfoMessageType = 'generation' | 'remix_reference';
 
@@ -159,6 +160,16 @@ interface AppState {
   saveImageGroup: (images: string[], prompt: string, title: string, meta: { model: string; size: string; quality: string; hadBaseImage: boolean }) => string[];
   deleteImage: (id: string) => void;
   newConversation: () => void;
+}
+
+function persistSavedImagesMeta(images: SavedImage[]) {
+  // Strip dataUrl before writing to localStorage. Blobs live in IndexedDB.
+  const meta = images.map(({ dataUrl, ...rest }) => rest);
+  try {
+    localStorage.setItem('saved_images', JSON.stringify(meta));
+  } catch (err) {
+    console.error('Failed to persist saved_images metadata:', err);
+  }
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -380,9 +391,20 @@ export const useAppStore = create<AppState>((set, get) => ({
     const updatedVideos = state.savedVideos.filter(v => v.conversationId !== id);
     localStorage.setItem('saved_videos', JSON.stringify(updatedVideos));
 
+    // Delete associated images (both metadata and IndexedDB blobs)
+    const orphanedImages = state.savedImages.filter((img) => img.conversationId === id);
+    const remainingImages = state.savedImages.filter((img) => img.conversationId !== id);
+    persistSavedImagesMeta(remainingImages);
+    if (orphanedImages.length > 0) {
+      deleteImagesFromIDB(orphanedImages.map((img) => img.id)).catch((err) =>
+        console.error('Failed to delete images from IDB:', err),
+      );
+    }
+
     set({
       savedConversations: updatedConversations,
       savedVideos: updatedVideos,
+      savedImages: remainingImages,
     });
   },
 
@@ -407,8 +429,13 @@ export const useAppStore = create<AppState>((set, get) => ({
       hadBaseImage: meta.hadBaseImage,
     }));
 
+    // Heavy base64 blobs go to IndexedDB (localStorage is too small).
+    Promise.all(entries.map((e) => putImage(e.id, e.dataUrl))).catch((err) => {
+      console.error('Failed to persist image to IndexedDB:', err);
+    });
+
     const updated = [...entries, ...state.savedImages];
-    localStorage.setItem('saved_images', JSON.stringify(updated));
+    persistSavedImagesMeta(updated);
     set({ savedImages: updated });
 
     return entries.map((e) => e.id);
@@ -417,8 +444,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   deleteImage: (id) => {
     const state = get();
     const updated = state.savedImages.filter((img) => img.id !== id);
-    localStorage.setItem('saved_images', JSON.stringify(updated));
+    persistSavedImagesMeta(updated);
     set({ savedImages: updated });
+    deleteImageFromIDB(id).catch((err) => console.error('Failed to delete image from IDB:', err));
   },
 
   saveVideo: (videoId, prompt, title, remixedFromVideoId = null) => {
@@ -511,7 +539,31 @@ if (typeof window !== 'undefined') {
   const storedImages = localStorage.getItem('saved_images');
   if (storedImages) {
     try {
-      useAppStore.setState({ savedImages: JSON.parse(storedImages) });
+      const parsed: SavedImage[] = JSON.parse(storedImages).map((img: any) => ({
+        ...img,
+        dataUrl: img.dataUrl ?? '',
+      }));
+      useAppStore.setState({ savedImages: parsed });
+
+      // Migrate: any legacy entries that still carry dataUrl inline get
+      // copied into IndexedDB so the next persist (metadata-only) is safe.
+      const legacy = parsed.filter((img) => img.dataUrl);
+      if (legacy.length > 0) {
+        Promise.all(legacy.map((img) => putImage(img.id, img.dataUrl)))
+          .then(() => persistSavedImagesMeta(parsed))
+          .catch((err) => console.error('Failed to migrate images to IDB:', err));
+      }
+
+      // Async-load blobs for entries that didn't have dataUrl inline.
+      Promise.all(
+        parsed.map(async (img) => {
+          if (img.dataUrl) return img;
+          const loaded = await getImage(img.id).catch(() => null);
+          return loaded ? { ...img, dataUrl: loaded } : img;
+        }),
+      ).then((withBlobs) => {
+        useAppStore.setState({ savedImages: withBlobs });
+      });
     } catch (e) {
       console.error('Failed to parse saved images');
     }

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -123,6 +123,8 @@ interface AppState {
   setShowVideoHistory: (show: boolean) => void;
 
   // Chat
+  chatInput: string;
+  setChatInput: (value: string) => void;
   chatMessages: ChatMessage[];
   addChatMessage: (message: Omit<ChatMessage, 'id' | 'timestamp'>) => void;
   readyToGenerate: boolean;
@@ -222,6 +224,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   setShowVideoHistory: (show) => set({ showVideoHistory: show }),
 
   // Chat
+  chatInput: '',
+  setChatInput: (value) => set({ chatInput: value }),
   chatMessages: [
     {
       id: 'welcome',
@@ -441,6 +445,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       readyToGenerate: false,
       baseImage: null,
       remixReference: null,
+      chatInput: '',
     });
   },
 }));

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,403 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "Sora-Studio"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260418233301_setup_sora_storage.sql
+++ b/supabase/migrations/20260418233301_setup_sora_storage.sql
@@ -1,0 +1,14 @@
+-- Make the sora bucket public so getPublicUrl returns accessible links.
+update storage.buckets set public = true where id = 'sora';
+
+-- Allow client-side uploads via the anon key.
+create policy "sora anon upload"
+  on storage.objects for insert
+  to anon
+  with check (bucket_id = 'sora');
+
+-- Explicit SELECT policy (also covered by public bucket, but explicit is nicer).
+create policy "sora anon read"
+  on storage.objects for select
+  to anon
+  using (bucket_id = 'sora');


### PR DESCRIPTION
## Summary

Adds a first-class **image generation mode** alongside the existing video flow. The left sidebar gains an **Images** tab, the header grows a **Video / Image** toggle, the config panel swaps to image-specific options, and a new opt-in **Supabase cloud sync** lets each user ship generated images to their own bucket for cross-device backup.

This is built on the **OpenAI Images API** (`gpt-image-1.5` / `gpt-image-1` / `gpt-image-1-mini`), not the Sora Videos API — those endpoints are independent, and the Sora web UI only *looks* unified because the product bundles them behind one chat. The API surface is two separate things.

## Why

- Today the tool only does Sora 2 video. Adding image gen unlocks quick single-frame work, experimentation, and **image → video remix** (the image endpoint already produces 1024×1024 / 1024×1536 / 1536×1024 outputs that drop straight into Sora's `input_reference`).
- Users asked for a 1–4 count picker like the sora.com UI has. `images.generate` natively supports `n: 1..4` (the video API does not), so this is the natural place to expose it.
- Base64 image data URLs blow past the ~5 MB localStorage quota after a few runs; that was causing hard failures where the API call succeeded (tokens spent) but the save step threw `QuotaExceededError`. Images had to move to IndexedDB.
- Token costs are invisible in the UI — users can't tell whether they're about to spend \$0.009 or \$0.20 per click. A cost estimate removes that footgun for both image and video modes.

## What's in the PR

### 1. Image generation (core flow)
- `POST /api/images/create` route wrapping `openai.images.generate` (and `.edit` when a base image is attached) with `n: 1..4`, size, quality, model.
- `useImageGeneration` hook that mirrors the existing `useVideoGeneration` pattern: collects prompt from chat, handles the base-image upload, emits `info` chat messages, and stores the result as a grouped `SavedImage` set.
- Header toggle **Video / Image**, count pills **1 / 2 / 3 / 4**, dynamic **Generate** button label.
- **Images** tab in the left sidebar with a grouped grid view (download / delete per image).
- Chat messages render the attached image grid inline with hover-download.

### 2. UX refinements
- **Auto-flush chat input**: clicking Generate in Image mode no longer requires a separate Send — the typed prompt is pushed into chat automatically.
- **Elapsed-time counter** on the Generate button (`Generating 1 image... 12s`) because the Images API is synchronous and has no progress stream.
- **Optional streaming preview** via Responses API + `image_generation` tool with `partial_images`. Hidden behind a toggle (currently disabled / Coming soon) because each partial frame costs ~100 output tokens per image — default stays at the cheapest path.
- **Cost estimate** card in the ConfigPanel for both modes:
  - Images: per-image price × n, from a lookup table covering gpt-image-1.5 / gpt-image-1 / gpt-image-1-mini at low / medium / high across supported sizes.
  - Video: per-second price × seconds, from the published Sora 2 / Sora 2 Pro rates.
- ConfigPanel becomes **mode-aware**: video mode keeps Resolution + Duration; image mode shows Model + Size + Quality + Live preview toggle.

### 3. Storage fix
- `lib/imageStorage.ts` — minimal IndexedDB wrapper (`put / get / delete / deleteImages`).
- `saveImageGroup` writes metadata to localStorage and the heavy base64 blob to IndexedDB.
- Hydration migrates any legacy `saved_images` entries that still carry `dataUrl` inline into IDB before the next persist strips them.
- `deleteConversation` and `deleteImage` clean up the associated IDB entries. Components render a pulse skeleton while the blob is lazy-loaded.
- Chat message ids now combine `Date.now()` with a random suffix so two adds in the same millisecond can't collide on the React key (regressed with the new auto-flush behaviour).

### 4. Optional Supabase cloud sync (BYO credentials)
- `lib/supabaseSync.ts` — tiny wrapper around `@supabase/supabase-js` exposing `uploadImage`, `removeImage`, `testConnection`.
- **Settings → Cloud Sync (Supabase)** section with Project URL / anon key / bucket inputs, Test connection, Save & enable, Disconnect.
- When enabled, `saveImageGroup` uploads each generated image to the user's bucket **in background** (does not block the UI) and records `cloudUrl` + `cloudPath` on the metadata. `deleteImage` also removes the blob from the bucket.
- Inputs strip embedded whitespace on save (pasting a JWT from a CLI wrap was silently corrupting it and producing `signature verification failed`) and suppress browser autofill / password-manager suggestions.
- A **versioned migration** (`supabase/migrations/20260418233301_setup_sora_storage.sql`) marks the bucket public and adds the anon INSERT / SELECT policies. `supabase init` output (`config.toml`, `.gitignore`) is committed so other contributors can `supabase link` and `supabase db push` to reproduce.

### Why Supabase specifically

For an open-source project we want the default deployment path to be zero-infra for the maintainer and zero-account for the casual user, but still allow real persistence for people who want it. Supabase hits that sweet spot:

- **No backend of our own.** Uploads go from the browser straight to Supabase Storage using the anon key. We never see the image blob.
- **User owns the data.** Each user points the app at their own Supabase project. They control the bucket, the URLs, and can delete everything with one click in their dashboard. The maintainer has no shared bucket to pay for or moderate.
- **Generous free tier** (1 GB storage + 5 GB bandwidth) covers normal personal use without a credit card.
- **Not tied to Vercel / any platform.** Works on Vercel, Netlify, Cloudflare Pages, self-hosted — because the cloud call is purely client-side.
- **RLS + versioned SQL migrations** instead of bespoke IAM. The policies are tiny and auditable in one file.
- Alternatives considered: Vercel Blob (couples to Vercel), S3 / R2 (require backend-signed URLs or CORS gymnastics for client uploads), OpenAI Files API (not designed for user galleries, no browse UI).

Cloud sync stays **strictly optional**: nothing breaks without it. Everything works offline-first via IndexedDB; Supabase just mirrors the data so it survives a device switch or a cleared browser profile.

## Files touched

- New: `app/api/images/create/route.ts`, `app/api/images/generate-stream/route.ts`, `lib/useImageGeneration.ts`, `lib/imageStorage.ts`, `lib/supabaseSync.ts`, `lib/imagePricing.ts`, `lib/videoPricing.ts`, `supabase/` (init + migration).
- Modified: `app/page.tsx` (mode toggle, count pills, Images tab, preview strip, elapsed counter), `store/useAppStore.ts` (image state + cloud config + safer persistence), `components/chat/ChatPanel.tsx` (lift chat input to store for auto-flush), `components/chat/ChatMessage.tsx` (render image grid), `components/ui/ConfigPanel.tsx` (mode-aware config + cost cards), `components/ui/SettingsPanel.tsx` (Cloud Sync section).

## Demo

### Adding Supabase cloud sync

https://github.com/user-attachments/assets/64361023-0506-4a38-89cc-4f2e60db4a2a

### Generating an image

Prompt: *Draw a gorgeous image of a river made of white owl feathers, snaking its way through a serene winter landscape*

https://github.com/user-attachments/assets/fc62f368-9618-4cae-b245-80c77de3696b

### Result

<img width="1608" height="960" alt="Screenshot 2026-04-18 at 21 33 07" src="https://github.com/user-attachments/assets/cb705204-8329-4337-a5e8-37459c20c312" />

## Test plan

- [x] Generate 1, 2, 3, 4 images with each model (gpt-image-1.5 / gpt-image-1-mini) and verify grid renders + download works
- [x] Attach a base image and confirm `images.edit` is used (single image edits render correctly)
- [x] Generate enough large images to exceed the old ~5 MB localStorage budget — no more QuotaExceededError, IDB holds the blobs, UI still renders
- [x] Reload the page and confirm the Images tab lazily rehydrates from IDB (skeleton → image)
- [x] Delete an image and confirm it disappears from IDB (and from Supabase when sync is on)
- [x] Switch Video ↔ Image in the header and confirm the ConfigPanel swaps
- [x] Change model / quality / size / count and watch the cost card update live
- [x] Video cost card reflects Sora 2 vs Sora 2 Pro and reacts to resolution + duration
- [x] Apply the Supabase migration (`supabase db push`), confirm the `sora` bucket is public and the anon upload / read policies exist
- [x] Configure Cloud Sync in the app with Project URL + anon key + bucket, hit Test connection (green), Save & enable
- [x] Generate an image with cloud sync enabled, confirm the object appears in the bucket and `cloudUrl` lands on the metadata
- [x] Paste a JWT with embedded whitespace (simulating a wrapped copy/paste) — the input strips it before saving instead of producing `signature verification failed`